### PR TITLE
fix: critical MJCF bugs and round-2 quality improvements

### DIFF
--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -26,8 +26,13 @@ from mujoco_models.shared.utils.mjcf_helpers import (
 
 logger = logging.getLogger(__name__)
 
+# Shared initial angles for floor-pull exercises (deadlift, snatch, clean-and-jerk).
+# Defined here so subclasses can import from a single authoritative location.
+FLOOR_PULL_HIP_FLEX: float = 1.3963  # ~80° hip flexion (radians)
+FLOOR_PULL_KNEE_FLEX: float = -1.0472  # ~60° knee flexion (radians)
 
-@dataclass
+
+@dataclass(frozen=True)
 class ExerciseConfig:
     """Configuration common to all exercise models."""
 
@@ -65,6 +70,17 @@ class ExerciseModelBuilder(ABC):
     @abstractmethod
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set default coordinate values for the starting position."""
+
+    def _post_worldbody_hook(  # noqa: B027
+        self, worldbody: ET.Element, equality: ET.Element
+    ) -> None:
+        """No-op hook called after worldbody is built, before actuator generation.
+
+        Subclasses may override to inject additional bodies or constraints
+        (e.g. BenchPressModelBuilder adds the bench body here).
+        This is an intentional empty method — not abstract — so the base class
+        remains instantiable and subclasses are not required to override it.
+        """
 
     def _attach_barbell_to_hands(
         self,
@@ -110,8 +126,8 @@ class ExerciseModelBuilder(ABC):
             timestep="0.001",
         )
 
-        # Compiler settings (Z-up)
-        ET.SubElement(root, "compiler", angle="radian", coordinate="local")
+        # Compiler settings (Z-up). coordinate='local' was removed in MuJoCo 2.1.4.
+        ET.SubElement(root, "compiler", angle="radian")
 
         # Default joint damping
         default = ET.SubElement(root, "default")
@@ -145,14 +161,17 @@ class ExerciseModelBuilder(ABC):
         # Exercise-specific attachment
         self.attach_barbell(equality, body_bodies, barbell_bodies)
 
+        # Subclass hook: inject extra bodies/constraints before actuator generation
+        self._post_worldbody_hook(worldbody, equality)
+
         # Exercise-specific initial pose
         self.set_initial_pose(worldbody)
 
-        # Add position actuators for all hinge joints
+        # Add position actuators for all hinge joints.
+        # Note: worldbody.iter("joint") only finds <joint> elements, never
+        # <freejoint> elements, so no freejoint guard is needed here.
         actuator = ET.SubElement(root, "actuator")
         for joint in worldbody.iter("joint"):
-            if joint.get("type", "hinge") == "free":
-                continue
             name = joint.get("name", "")
             if name:
                 act = ET.SubElement(actuator, "position")
@@ -160,11 +179,11 @@ class ExerciseModelBuilder(ABC):
                 act.set("joint", name)
                 act.set("kp", "100")
 
-        # Add joint position sensors
+        # Add joint position sensors.
+        # Note: worldbody.iter("joint") only finds <joint> elements, never
+        # <freejoint> elements, so no freejoint guard is needed here.
         sensor = ET.SubElement(root, "sensor")
         for joint in worldbody.iter("joint"):
-            if joint.get("type", "hinge") == "free":
-                continue
             name = joint.get("name", "")
             if name:
                 s = ET.SubElement(sensor, "jointpos")

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -19,7 +19,6 @@ MuJoCo Z-up convention: gravity = (0, 0, -9.80665).
 from __future__ import annotations
 
 import logging
-import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
@@ -41,9 +40,6 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
     The barbell shaft is welded to both hands at grip width.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "bench_press"
@@ -60,6 +56,10 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         on each side for a standard grip).
         """
         self._attach_barbell_to_hands(equality)
+
+    def _post_worldbody_hook(self, worldbody: ET.Element, equality: ET.Element) -> None:
+        """Add bench body and weld pelvis to it."""
+        self._add_bench(worldbody, equality)
 
     def _add_bench(self, worldbody: ET.Element, equality: ET.Element) -> None:
         """Add a bench body and weld the pelvis to it."""
@@ -82,98 +82,24 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         logger.debug("Added bench body at height %.3f m", BENCH_HEIGHT)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
-        """Set supine lockout position: shoulder and elbow joint refs."""
+        """Set supine lockout position: shoulder and elbow joint refs.
+
+        Ref values are stored in radians to match <compiler angle='radian'>.
+        """
         for joint in worldbody.iter("joint"):
             name = joint.get("name", "")
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
             if "shoulder" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_SHOULDER_FLEX)))
+                joint.set("ref", str(_INITIAL_SHOULDER_FLEX))
             elif "elbow" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_ELBOW_FLEX)))
+                joint.set("ref", str(_INITIAL_ELBOW_FLEX))
         logger.debug(
-            "Setting bench press initial pose: shoulder=%.1f°, elbow=%.1f°",
-            math.degrees(_INITIAL_SHOULDER_FLEX),
-            math.degrees(_INITIAL_ELBOW_FLEX),
+            "Setting bench press initial pose: shoulder=%.4f rad, elbow=%.4f rad",
+            _INITIAL_SHOULDER_FLEX,
+            _INITIAL_ELBOW_FLEX,
         )
-
-    def build(self) -> str:
-        """Build bench press model, adding bench body and pelvis weld."""
-        return self._build_with_bench()
-
-    def _build_with_bench(self) -> str:
-        """Full build with bench body injected before serialization."""
-        from mujoco_models.shared.barbell import create_barbell_bodies
-        from mujoco_models.shared.body import create_full_body
-        from mujoco_models.shared.contracts.postconditions import ensure_mjcf_root
-        from mujoco_models.shared.utils.mjcf_helpers import serialize_model
-
-        logger.info("Building %s model (with bench)", self.exercise_name)
-
-        root = ET.Element("mujoco", model=self.exercise_name)
-
-        g = self.config.gravity
-        ET.SubElement(
-            root,
-            "option",
-            gravity=f"{g[0]:.6f} {g[1]:.6f} {g[2]:.6f}",
-            timestep="0.001",
-        )
-        ET.SubElement(root, "compiler", angle="radian", coordinate="local")
-
-        default = ET.SubElement(root, "default")
-        ET.SubElement(default, "joint", damping="5.0", armature="0.1")
-        ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="3")
-
-        worldbody = ET.SubElement(root, "worldbody")
-        ET.SubElement(
-            worldbody,
-            "geom",
-            name="ground",
-            type="plane",
-            size="5 5 0.1",
-            rgba="0.9 0.9 0.9 1",
-        )
-
-        equality = ET.SubElement(root, "equality")
-
-        body_bodies = create_full_body(worldbody, self.config.body_spec)
-        barbell_bodies = create_barbell_bodies(
-            worldbody, equality, self.config.barbell_spec
-        )
-
-        self.attach_barbell(equality, body_bodies, barbell_bodies)
-        self._add_bench(worldbody, equality)
-        self.set_initial_pose(worldbody)
-
-        # Add position actuators for all hinge joints
-        actuator = ET.SubElement(root, "actuator")
-        for joint in worldbody.iter("joint"):
-            if joint.get("type", "hinge") == "free":
-                continue
-            jname = joint.get("name", "")
-            if jname:
-                act = ET.SubElement(actuator, "position")
-                act.set("name", f"act_{jname}")
-                act.set("joint", jname)
-                act.set("kp", "100")
-
-        # Add joint position sensors
-        sensor = ET.SubElement(root, "sensor")
-        for joint in worldbody.iter("joint"):
-            if joint.get("type", "hinge") == "free":
-                continue
-            jname = joint.get("name", "")
-            if jname:
-                s = ET.SubElement(sensor, "jointpos")
-                s.set("name", f"pos_{jname}")
-                s.set("joint", jname)
-
-        xml_str = serialize_model(root)
-        ensure_mjcf_root(xml_str)
-        logger.debug("Successfully built %s model", self.exercise_name)
-        return xml_str
 
 
 def build_bench_press_model(

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -29,16 +29,20 @@ The barbell is welded to both hands at clean grip width.
 from __future__ import annotations
 
 import logging
-import math
 import xml.etree.ElementTree as ET
 
-from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from mujoco_models.exercises.base import (
+    FLOOR_PULL_HIP_FLEX,
+    FLOOR_PULL_KNEE_FLEX,
+    ExerciseConfig,
+    ExerciseModelBuilder,
+)
 
 logger = logging.getLogger(__name__)
 
-# Deep hip hinge starting position (same as deadlift)
-_INITIAL_HIP_FLEX = 1.3963  # ~80 degrees
-_INITIAL_KNEE_FLEX = -1.0472  # ~60 degrees
+# Deep hip hinge starting position — same as deadlift (shared constants).
+_INITIAL_HIP_FLEX = FLOOR_PULL_HIP_FLEX
+_INITIAL_KNEE_FLEX = FLOOR_PULL_KNEE_FLEX
 
 
 class CleanAndJerkModelBuilder(ExerciseModelBuilder):
@@ -47,9 +51,6 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
     Uses shoulder-width grip. The model supports both the clean
     (floor to shoulders) and jerk (shoulders to overhead) phases.
     """
-
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
 
     @property
     def exercise_name(self) -> str:
@@ -68,20 +69,23 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
         self._attach_barbell_to_hands(equality)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
-        """Set starting position: bar on floor, clean grip, hip hinge."""
+        """Set starting position: bar on floor, clean grip, hip hinge.
+
+        Ref values are stored in radians to match <compiler angle='radian'>.
+        """
         for joint in worldbody.iter("joint"):
             name = joint.get("name", "")
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
             if "hip" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_HIP_FLEX)))
+                joint.set("ref", str(_INITIAL_HIP_FLEX))
             elif "knee" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_KNEE_FLEX)))
+                joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting clean & jerk initial pose: hip_flex=%.1f°, knee_flex=%.1f°",
-            math.degrees(_INITIAL_HIP_FLEX),
-            math.degrees(_INITIAL_KNEE_FLEX),
+            "Setting clean & jerk initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            _INITIAL_HIP_FLEX,
+            _INITIAL_KNEE_FLEX,
         )
 
 

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -19,18 +19,22 @@ and knee flexion to reach the bar on the ground.
 from __future__ import annotations
 
 import logging
-import math
 import xml.etree.ElementTree as ET
 
-from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from mujoco_models.exercises.base import (
+    FLOOR_PULL_HIP_FLEX,
+    FLOOR_PULL_KNEE_FLEX,
+    ExerciseConfig,
+    ExerciseModelBuilder,
+)
 
 logger = logging.getLogger(__name__)
 
 PLATE_RADIUS = 0.225  # Standard 450mm diameter plate radius
 
-# Deep hip hinge starting position (radians)
-_INITIAL_HIP_FLEX = 1.3963  # ~80 degrees
-_INITIAL_KNEE_FLEX = -1.0472  # ~60 degrees
+# Re-export shared constants under the local names used by tests.
+_INITIAL_HIP_FLEX = FLOOR_PULL_HIP_FLEX
+_INITIAL_KNEE_FLEX = FLOOR_PULL_KNEE_FLEX
 
 
 class DeadliftModelBuilder(ExerciseModelBuilder):
@@ -38,9 +42,6 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
     The barbell is welded to both hands and starts on the floor.
     """
-
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
 
     @property
     def exercise_name(self) -> str:
@@ -63,6 +64,8 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
         The bar is on the floor at PLATE_RADIUS height, so the body
         must flex at the hips (~80 deg) and knees (~60 deg) to reach.
+
+        Ref values are stored in radians to match <compiler angle='radian'>.
         """
         for joint in worldbody.iter("joint"):
             name = joint.get("name", "")
@@ -70,13 +73,13 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
             if joint_type != "hinge":
                 continue
             if "hip" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_HIP_FLEX)))
+                joint.set("ref", str(_INITIAL_HIP_FLEX))
             elif "knee" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_KNEE_FLEX)))
+                joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting deadlift initial pose: hip_flex=%.1f°, knee_flex=%.1f°",
-            math.degrees(_INITIAL_HIP_FLEX),
-            math.degrees(_INITIAL_KNEE_FLEX),
+            "Setting deadlift initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            _INITIAL_HIP_FLEX,
+            _INITIAL_KNEE_FLEX,
         )
 
 

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -25,23 +25,24 @@ The barbell is welded to both hands with a wide grip offset.
 from __future__ import annotations
 
 import logging
-import math
 import xml.etree.ElementTree as ET
 
-from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from mujoco_models.exercises.base import (
+    FLOOR_PULL_HIP_FLEX,
+    FLOOR_PULL_KNEE_FLEX,
+    ExerciseConfig,
+    ExerciseModelBuilder,
+)
 
 logger = logging.getLogger(__name__)
 
-# Deep hip hinge starting position (same as deadlift)
-_INITIAL_HIP_FLEX = 1.3963  # ~80 degrees
-_INITIAL_KNEE_FLEX = -1.0472  # ~60 degrees
+# Deep hip hinge starting position — same as deadlift (shared constants).
+_INITIAL_HIP_FLEX = FLOOR_PULL_HIP_FLEX
+_INITIAL_KNEE_FLEX = FLOOR_PULL_KNEE_FLEX
 
 
 class SnatchModelBuilder(ExerciseModelBuilder):
     """Builds a snatch MuJoCo MJCF model with wide grip."""
-
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
 
     @property
     def exercise_name(self) -> str:
@@ -61,20 +62,23 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         self._attach_barbell_to_hands(equality)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
-        """Set starting position: bar on floor, wide grip, deep hip hinge."""
+        """Set starting position: bar on floor, wide grip, deep hip hinge.
+
+        Ref values are stored in radians to match <compiler angle='radian'>.
+        """
         for joint in worldbody.iter("joint"):
             name = joint.get("name", "")
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
             if "hip" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_HIP_FLEX)))
+                joint.set("ref", str(_INITIAL_HIP_FLEX))
             elif "knee" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_KNEE_FLEX)))
+                joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting snatch initial pose: hip_flex=%.1f°, knee_flex=%.1f°",
-            math.degrees(_INITIAL_HIP_FLEX),
-            math.degrees(_INITIAL_KNEE_FLEX),
+            "Setting snatch initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            _INITIAL_HIP_FLEX,
+            _INITIAL_KNEE_FLEX,
         )
 
 

--- a/src/mujoco_models/exercises/squat/squat_model.py
+++ b/src/mujoco_models/exercises/squat/squat_model.py
@@ -15,7 +15,6 @@ Biomechanical notes:
 from __future__ import annotations
 
 import logging
-import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
@@ -35,9 +34,6 @@ class SquatModelBuilder(ExerciseModelBuilder):
     upper trapezius (high-bar squat). For a low-bar variant, the attachment
     point would be shifted ~5 cm inferior.
     """
-
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
 
     @property
     def exercise_name(self) -> str:
@@ -62,6 +58,8 @@ class SquatModelBuilder(ExerciseModelBuilder):
 
         The lifter starts in a comfortable standing position with the
         barbell on the back, knees slightly unlocked.
+
+        Ref values are stored in radians to match <compiler angle='radian'>.
         """
         for joint in worldbody.iter("joint"):
             name = joint.get("name", "")
@@ -69,13 +67,13 @@ class SquatModelBuilder(ExerciseModelBuilder):
             if joint_type != "hinge":
                 continue
             if "hip" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_HIP_FLEX)))
+                joint.set("ref", str(_INITIAL_HIP_FLEX))
             elif "knee" in name:
-                joint.set("ref", str(math.degrees(_INITIAL_KNEE_FLEX)))
+                joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting squat initial pose: hip_flex=%.1f°, knee_flex=%.1f°",
-            math.degrees(_INITIAL_HIP_FLEX),
-            math.degrees(_INITIAL_KNEE_FLEX),
+            "Setting squat initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            _INITIAL_HIP_FLEX,
+            _INITIAL_KNEE_FLEX,
         )
 
 

--- a/tests/integration/test_mujoco_loading.py
+++ b/tests/integration/test_mujoco_loading.py
@@ -1,0 +1,54 @@
+"""Integration tests: verify MJCF models load into MuJoCo without errors."""
+
+import pytest
+
+try:
+    import mujoco
+
+    _MUJOCO_AVAILABLE = True
+except ImportError:
+    _MUJOCO_AVAILABLE = False
+
+_SKIP_MUJOCO = pytest.mark.skipif(
+    not _MUJOCO_AVAILABLE,
+    reason="mujoco not installed in this environment",
+)
+
+# These imports come after the try/except guard so that E402 is expected here.
+from mujoco_models.exercises.bench_press.bench_press_model import (  # noqa: E402
+    build_bench_press_model,
+)
+from mujoco_models.exercises.clean_and_jerk.clean_and_jerk_model import (  # noqa: E402
+    build_clean_and_jerk_model,
+)
+from mujoco_models.exercises.deadlift.deadlift_model import (  # noqa: E402
+    build_deadlift_model,
+)
+from mujoco_models.exercises.snatch.snatch_model import build_snatch_model  # noqa: E402
+from mujoco_models.exercises.squat.squat_model import build_squat_model  # noqa: E402
+
+ALL_BUILDERS = [
+    ("squat", build_squat_model),
+    ("bench_press", build_bench_press_model),
+    ("deadlift", build_deadlift_model),
+    ("snatch", build_snatch_model),
+    ("clean_and_jerk", build_clean_and_jerk_model),
+]
+_IDS = [n for n, _ in ALL_BUILDERS]
+
+
+@_SKIP_MUJOCO
+class TestMuJoCoLoading:
+    @pytest.mark.parametrize("name,builder", ALL_BUILDERS, ids=_IDS)
+    def test_model_loads_without_error(self, name: str, builder: object) -> None:
+        xml_str = builder()
+        model = mujoco.MjModel.from_xml_string(xml_str)
+        assert model.nbody > 1, f"{name}: no bodies after loading"
+
+    @pytest.mark.parametrize("name,builder", ALL_BUILDERS, ids=_IDS)
+    def test_model_has_correct_joint_count(self, name: str, builder: object) -> None:
+        xml_str = builder()
+        model = mujoco.MjModel.from_xml_string(xml_str)
+        # 14 hinge joints: lumbar, neck, 2 shoulder, 2 elbow, 2 wrist,
+        # 2 hip, 2 knee, 2 ankle
+        assert model.njnt >= 14, f"{name}: expected >= 14 joints, got {model.njnt}"

--- a/tests/unit/exercises/bench_press/test_bench_press_model.py
+++ b/tests/unit/exercises/bench_press/test_bench_press_model.py
@@ -63,8 +63,6 @@ class TestBenchPressModelBuilder:
         assert joint.get("ref") is not None, "shoulder joint should have ref set"
 
     def test_set_initial_pose_shoulder_ref(self) -> None:
-        import math
-
         from mujoco_models.exercises.bench_press.bench_press_model import (
             _INITIAL_SHOULDER_FLEX,
         )
@@ -75,8 +73,9 @@ class TestBenchPressModelBuilder:
         ET.SubElement(body, "joint", name="shoulder_r_flex", type="hinge")
         builder.set_initial_pose(worldbody)
         joint = worldbody.find(".//joint")
+        # ref is stored in radians (matches <compiler angle='radian'>)
         assert float(joint.get("ref")) == pytest.approx(
-            math.degrees(_INITIAL_SHOULDER_FLEX), rel=1e-4
+            _INITIAL_SHOULDER_FLEX, rel=1e-4
         )
 
     def test_build_has_bench_body(self) -> None:

--- a/tests/unit/exercises/deadlift/test_deadlift_model.py
+++ b/tests/unit/exercises/deadlift/test_deadlift_model.py
@@ -60,8 +60,6 @@ class TestDeadliftModelBuilder:
         builder.set_initial_pose(worldbody)
 
     def test_set_initial_pose_modifies_hip_joints(self) -> None:
-        import math
-
         from mujoco_models.exercises.deadlift.deadlift_model import _INITIAL_HIP_FLEX
 
         builder = DeadliftModelBuilder()
@@ -70,9 +68,8 @@ class TestDeadliftModelBuilder:
         joint = ET.SubElement(body, "joint", name="hip_l_flex", type="hinge")
         builder.set_initial_pose(worldbody)
         assert joint.get("ref") is not None
-        assert float(joint.get("ref")) == pytest.approx(
-            math.degrees(_INITIAL_HIP_FLEX), rel=1e-4
-        )
+        # ref is stored in radians (matches <compiler angle='radian'>)
+        assert float(joint.get("ref")) == pytest.approx(_INITIAL_HIP_FLEX, rel=1e-4)
 
     def test_build_has_actuators(self) -> None:
         xml_str = build_deadlift_model()

--- a/tests/unit/exercises/squat/test_squat_model.py
+++ b/tests/unit/exercises/squat/test_squat_model.py
@@ -65,8 +65,6 @@ class TestSquatModelBuilder:
         builder.set_initial_pose(worldbody)
 
     def test_set_initial_pose_modifies_hip_joints(self) -> None:
-        import math
-
         from mujoco_models.exercises.squat.squat_model import _INITIAL_HIP_FLEX
 
         builder = SquatModelBuilder()
@@ -75,13 +73,10 @@ class TestSquatModelBuilder:
         joint = ET.SubElement(body, "joint", name="hip_l_flex", type="hinge")
         builder.set_initial_pose(worldbody)
         assert joint.get("ref") is not None
-        assert float(joint.get("ref")) == pytest.approx(
-            math.degrees(_INITIAL_HIP_FLEX), rel=1e-4
-        )
+        # ref is stored in radians (matches <compiler angle='radian'>)
+        assert float(joint.get("ref")) == pytest.approx(_INITIAL_HIP_FLEX, rel=1e-4)
 
     def test_set_initial_pose_modifies_knee_joints(self) -> None:
-        import math
-
         from mujoco_models.exercises.squat.squat_model import _INITIAL_KNEE_FLEX
 
         builder = SquatModelBuilder()
@@ -90,9 +85,8 @@ class TestSquatModelBuilder:
         joint = ET.SubElement(body, "joint", name="knee_r_flex", type="hinge")
         builder.set_initial_pose(worldbody)
         assert joint.get("ref") is not None
-        assert float(joint.get("ref")) == pytest.approx(
-            math.degrees(_INITIAL_KNEE_FLEX), rel=1e-4
-        )
+        # ref is stored in radians (matches <compiler angle='radian'>)
+        assert float(joint.get("ref")) == pytest.approx(_INITIAL_KNEE_FLEX, rel=1e-4)
 
     def test_build_has_actuators(self) -> None:
         xml_str = build_squat_model()

--- a/tests/unit/shared/test_segment_data.py
+++ b/tests/unit/shared/test_segment_data.py
@@ -43,7 +43,7 @@ class TestSegmentTable:
 
     def test_total_mass_fraction_near_one(self) -> None:
         total = total_mass_fraction()
-        assert total == pytest.approx(1.0, abs=0.02)
+        assert total == pytest.approx(1.0, rel=1e-6)
 
     def test_segment_has_three_keys(self) -> None:
         for name, props in SEGMENT_TABLE.items():


### PR DESCRIPTION
Closes #32, #33, #34, #35, #37, #39

## Changes

- **Remove `coordinate='local'`** from all compiler elements — removed in MuJoCo 2.1.4, breaks all models in MuJoCo 3.x (fixes #34)
- **Fix `ref` stored as degrees instead of radians** — `math.degrees(val)` was written but `<compiler angle='radian'>` reads radians; 80° was being read as 80 rad (~4,580°) (fixes #32)
- **Fix tests that asserted the degree bug** — bench_press, deadlift, squat tests now assert radian values (fixes #33)
- **Add MuJoCo integration test suite** — `tests/integration/test_mujoco_loading.py` with skip guard when mujoco is not installed (fixes #35)
- **Remove duplicated `bench_press` build() pipeline** — added `_post_worldbody_hook` no-op to `base.py`; `BenchPressModelBuilder` now overrides only the hook instead of duplicating ~70 lines (fixes #37)
- **Remove trivial `__init__` overrides** — deleted `def __init__(self, config): super().__init__(config)` from all 5 exercise subclasses (fixes #39)
- **Extract shared floor-pull constants** — `FLOOR_PULL_HIP_FLEX` / `FLOOR_PULL_KNEE_FLEX` in `base.py`; deadlift, snatch, clean_and_jerk import from there (fixes #39)
- **Remove dead freejoint guard** — `iter("joint")` never yields `<freejoint>` elements; guard was unreachable dead code (fixes #39)
- **Tighten mass fraction test tolerance** — `abs=0.02` to `rel=1e-6` (fixes #39)
- **Make `ExerciseConfig` frozen** — `@dataclass(frozen=True)` (fixes #39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)