### PR TITLE
feat: multi-DOF joint upgrade for biomechanical accuracy

### DIFF
--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -19,6 +19,7 @@ MuJoCo Z-up convention: gravity = (0, 0, -9.80665).
 from __future__ import annotations
 
 import logging
+import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
@@ -30,6 +31,7 @@ BENCH_HEIGHT = 0.43  # IPF standard bench height (meters)
 
 # Supine lockout position hints (radians)
 _INITIAL_SHOULDER_FLEX = -1.5708  # arms overhead (~90 deg from standing)
+_INITIAL_SHOULDER_ADDUCT = math.radians(75)  # ~75° adduction for horizontal press plane
 _INITIAL_ELBOW_FLEX = 0.0  # fully extended
 
 
@@ -84,6 +86,8 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set supine lockout position: shoulder and elbow joint refs.
 
+        Shoulder adduction positions the arms in the horizontal press plane.
+
         Ref values are stored in radians to match <compiler angle='radian'>.
         """
         for joint in worldbody.iter("joint"):
@@ -91,13 +95,17 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
-            if "shoulder" in name:
+            if name.endswith("_flex") and "shoulder" in name:
                 joint.set("ref", str(_INITIAL_SHOULDER_FLEX))
+            elif "shoulder" in name and "adduct" in name:
+                joint.set("ref", str(_INITIAL_SHOULDER_ADDUCT))
             elif "elbow" in name:
                 joint.set("ref", str(_INITIAL_ELBOW_FLEX))
         logger.debug(
-            "Setting bench press initial pose: shoulder=%.4f rad, elbow=%.4f rad",
+            "Setting bench press initial pose: shoulder_flex=%.4f rad, "
+            "shoulder_adduct=%.4f rad, elbow=%.4f rad",
             _INITIAL_SHOULDER_FLEX,
+            _INITIAL_SHOULDER_ADDUCT,
             _INITIAL_ELBOW_FLEX,
         )
 

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -29,6 +29,7 @@ The barbell is welded to both hands at clean grip width.
 from __future__ import annotations
 
 import logging
+import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import (
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 # Deep hip hinge starting position — same as deadlift (shared constants).
 _INITIAL_HIP_FLEX = FLOOR_PULL_HIP_FLEX
 _INITIAL_KNEE_FLEX = FLOOR_PULL_KNEE_FLEX
+_INITIAL_SHOULDER_ROTATE = math.radians(45)  # ~45° external rotation for front rack
 
 
 class CleanAndJerkModelBuilder(ExerciseModelBuilder):
@@ -71,6 +73,8 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, clean grip, hip hinge.
 
+        Shoulder external rotation prepares the front rack position.
+
         Ref values are stored in radians to match <compiler angle='radian'>.
         """
         for joint in worldbody.iter("joint"):
@@ -78,14 +82,18 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
-            if "hip" in name:
+            if name.endswith("_flex") and "hip" in name:
                 joint.set("ref", str(_INITIAL_HIP_FLEX))
+            elif "shoulder" in name and "rotate" in name:
+                joint.set("ref", str(_INITIAL_SHOULDER_ROTATE))
             elif "knee" in name:
                 joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting clean & jerk initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            "Setting clean & jerk initial pose: hip_flex=%.4f rad, "
+            "knee_flex=%.4f rad, shoulder_rotate=%.4f rad",
             _INITIAL_HIP_FLEX,
             _INITIAL_KNEE_FLEX,
+            _INITIAL_SHOULDER_ROTATE,
         )
 
 

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -72,7 +72,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
-            if "hip" in name:
+            if name.endswith("_flex") and "hip" in name:
                 joint.set("ref", str(_INITIAL_HIP_FLEX))
             elif "knee" in name:
                 joint.set("ref", str(_INITIAL_KNEE_FLEX))

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -25,6 +25,7 @@ The barbell is welded to both hands with a wide grip offset.
 from __future__ import annotations
 
 import logging
+import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import (
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 # Deep hip hinge starting position — same as deadlift (shared constants).
 _INITIAL_HIP_FLEX = FLOOR_PULL_HIP_FLEX
 _INITIAL_KNEE_FLEX = FLOOR_PULL_KNEE_FLEX
+_INITIAL_SHOULDER_ADDUCT = math.radians(45)  # ~45° abduction for wide overhead grip
 
 
 class SnatchModelBuilder(ExerciseModelBuilder):
@@ -64,6 +66,8 @@ class SnatchModelBuilder(ExerciseModelBuilder):
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, wide grip, deep hip hinge.
 
+        Shoulder abduction opens the arms for the wide snatch grip.
+
         Ref values are stored in radians to match <compiler angle='radian'>.
         """
         for joint in worldbody.iter("joint"):
@@ -71,14 +75,18 @@ class SnatchModelBuilder(ExerciseModelBuilder):
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
-            if "hip" in name:
+            if name.endswith("_flex") and "hip" in name:
                 joint.set("ref", str(_INITIAL_HIP_FLEX))
+            elif "shoulder" in name and "adduct" in name:
+                joint.set("ref", str(_INITIAL_SHOULDER_ADDUCT))
             elif "knee" in name:
                 joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting snatch initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            "Setting snatch initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad, "
+            "shoulder_adduct=%.4f rad",
             _INITIAL_HIP_FLEX,
             _INITIAL_KNEE_FLEX,
+            _INITIAL_SHOULDER_ADDUCT,
         )
 
 

--- a/src/mujoco_models/exercises/squat/squat_model.py
+++ b/src/mujoco_models/exercises/squat/squat_model.py
@@ -15,6 +15,7 @@ Biomechanical notes:
 from __future__ import annotations
 
 import logging
+import math
 import xml.etree.ElementTree as ET
 
 from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Slight hip/knee flexion for unrack position (radians)
 _INITIAL_HIP_FLEX = 0.15  # ~8.6 degrees
 _INITIAL_KNEE_FLEX = -0.15  # slight knee bend
+_INITIAL_HIP_ROTATE = math.radians(10)  # ~10° external rotation for squat stance
 
 
 class SquatModelBuilder(ExerciseModelBuilder):
@@ -57,7 +59,8 @@ class SquatModelBuilder(ExerciseModelBuilder):
         """Set standing unrack position: slight hip and knee flexion.
 
         The lifter starts in a comfortable standing position with the
-        barbell on the back, knees slightly unlocked.
+        barbell on the back, knees slightly unlocked.  Hip external
+        rotation (~10 deg) opens the stance for squat mechanics.
 
         Ref values are stored in radians to match <compiler angle='radian'>.
         """
@@ -66,14 +69,18 @@ class SquatModelBuilder(ExerciseModelBuilder):
             joint_type = joint.get("type", "hinge")
             if joint_type != "hinge":
                 continue
-            if "hip" in name:
+            if name.endswith("_flex") and "hip" in name:
                 joint.set("ref", str(_INITIAL_HIP_FLEX))
+            elif "hip" in name and "rotate" in name:
+                joint.set("ref", str(_INITIAL_HIP_ROTATE))
             elif "knee" in name:
                 joint.set("ref", str(_INITIAL_KNEE_FLEX))
         logger.debug(
-            "Setting squat initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad",
+            "Setting squat initial pose: hip_flex=%.4f rad, knee_flex=%.4f rad, "
+            "hip_rotate=%.4f rad",
             _INITIAL_HIP_FLEX,
             _INITIAL_KNEE_FLEX,
+            _INITIAL_HIP_ROTATE,
         )
 
 

--- a/src/mujoco_models/shared/body/body_model.py
+++ b/src/mujoco_models/shared/body/body_model.py
@@ -5,16 +5,16 @@ Segments (bilateral where noted):
   upper_arm_{l,r}, forearm_{l,r}, hand_{l,r},
   thigh_{l,r}, shank_{l,r}, foot_{l,r}
 
-Joints:
+Joints (multi-DOF where physiologically appropriate):
   ground_pelvis (freejoint -- 6 DOF),
-  lumbar (hinge -- flexion/extension),
+  lumbar (3-DOF: flex, lateral, rotate),
   neck (hinge),
-  shoulder_{l,r} (hinge -- simplified, flexion only for v0.1),
+  shoulder_{l,r} (3-DOF: flex, adduct, rotate),
   elbow_{l,r} (hinge),
-  wrist_{l,r} (hinge),
-  hip_{l,r} (hinge -- flexion/extension),
+  wrist_{l,r} (2-DOF: flex, deviate),
+  hip_{l,r} (3-DOF: flex, adduct, rotate),
   knee_{l,r} (hinge),
-  ankle_{l,r} (hinge)
+  ankle_{l,r} (2-DOF: flex, invert)
 
 Anthropometric defaults are for a 50th-percentile male (height=1.75 m,
 mass=80 kg) following Winter (2009) segment proportions.
@@ -31,7 +31,35 @@ import logging
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 
-from mujoco_models.shared.body.segment_data import segment_properties
+from mujoco_models.shared.body.segment_data import (
+    ANKLE_FLEX_MAX,
+    ANKLE_FLEX_MIN,
+    ANKLE_INVERT_MAX,
+    ANKLE_INVERT_MIN,
+    HIP_ADDUCT_MAX,
+    HIP_ADDUCT_MIN,
+    HIP_FLEX_MAX,
+    HIP_FLEX_MIN,
+    HIP_ROTATE_MAX,
+    HIP_ROTATE_MIN,
+    LUMBAR_FLEX_MAX,
+    LUMBAR_FLEX_MIN,
+    LUMBAR_LATERAL_MAX,
+    LUMBAR_LATERAL_MIN,
+    LUMBAR_ROTATE_MAX,
+    LUMBAR_ROTATE_MIN,
+    SHOULDER_ADDUCT_MAX,
+    SHOULDER_ADDUCT_MIN,
+    SHOULDER_FLEX_MAX,
+    SHOULDER_FLEX_MIN,
+    SHOULDER_ROTATE_MAX,
+    SHOULDER_ROTATE_MIN,
+    WRIST_DEVIATE_MAX,
+    WRIST_DEVIATE_MIN,
+    WRIST_FLEX_MAX,
+    WRIST_FLEX_MIN,
+    segment_properties,
+)
 from mujoco_models.shared.contracts.preconditions import (
     require_positive,
 )
@@ -83,12 +111,21 @@ def _add_bilateral_limb(
     coord_prefix: str,
     range_min: float,
     range_max: float,
+    extra_joints: list[tuple[str, tuple[float, float, float], float, float]]
+    | None = None,
 ) -> dict[str, ET.Element]:
     """Add left and right limb segments with hinge joints.
 
     MuJoCo convention: Z-up, so vertical offsets use Z coordinate.
     Hinge joints rotate about the X-axis (medio-lateral) by default
     for sagittal-plane flexion/extension.
+
+    Parameters
+    ----------
+    extra_joints : list of (suffix, axis, range_min, range_max) or None
+        Additional hinge joints to add after the primary flexion joint.
+        Each entry creates ``{coord_prefix}_{side}_{suffix}`` on the
+        given axis with the given range limits.
     """
     mass, length, radius = _seg(spec, seg_name)
     inertia = capsule_inertia(mass, radius, length)
@@ -123,6 +160,17 @@ def _add_bilateral_limb(
             range_min=range_min,
             range_max=range_max,
         )
+
+        # Add extra DOFs (stacked hinge joints on the same body)
+        if extra_joints:
+            for suffix, axis, ex_min, ex_max in extra_joints:
+                add_hinge_joint(
+                    child_body,
+                    name=f"{coord_prefix}_{side}_{suffix}",
+                    axis=axis,
+                    range_min=ex_min,
+                    range_max=ex_max,
+                )
 
         created[body_name] = child_body
 
@@ -185,8 +233,22 @@ def create_full_body(
         torso_body,
         name="lumbar_flex",
         axis=(1, 0, 0),
-        range_min=-0.5236,
-        range_max=0.7854,
+        range_min=LUMBAR_FLEX_MIN,
+        range_max=LUMBAR_FLEX_MAX,
+    )
+    add_hinge_joint(
+        torso_body,
+        name="lumbar_lateral",
+        axis=(0, 0, 1),
+        range_min=LUMBAR_LATERAL_MIN,
+        range_max=LUMBAR_LATERAL_MAX,
+    )
+    add_hinge_joint(
+        torso_body,
+        name="lumbar_rotate",
+        axis=(0, 1, 0),
+        range_min=LUMBAR_ROTATE_MIN,
+        range_max=LUMBAR_ROTATE_MAX,
     )
     bodies["torso"] = torso_body
 
@@ -224,8 +286,12 @@ def create_full_body(
         parent_offset_z=shoulder_z,
         parent_lateral_x=shoulder_x,
         coord_prefix="shoulder",
-        range_min=-3.1416,
-        range_max=3.1416,
+        range_min=SHOULDER_FLEX_MIN,
+        range_max=SHOULDER_FLEX_MAX,
+        extra_joints=[
+            ("adduct", (0, 0, 1), SHOULDER_ADDUCT_MIN, SHOULDER_ADDUCT_MAX),
+            ("rotate", (0, 1, 0), SHOULDER_ROTATE_MIN, SHOULDER_ROTATE_MAX),
+        ],
     )
     bodies.update(arm_bodies)
 
@@ -252,8 +318,11 @@ def create_full_body(
         parent_offset_z=-fa_len,
         parent_lateral_x=0,
         coord_prefix="wrist",
-        range_min=-1.2217,
-        range_max=1.2217,
+        range_min=WRIST_FLEX_MIN,
+        range_max=WRIST_FLEX_MAX,
+        extra_joints=[
+            ("deviate", (0, 0, 1), WRIST_DEVIATE_MIN, WRIST_DEVIATE_MAX),
+        ],
     )
     bodies.update(hand_bodies)
 
@@ -268,8 +337,12 @@ def create_full_body(
         parent_offset_z=-p_len / 2.0,
         parent_lateral_x=hip_x,
         coord_prefix="hip",
-        range_min=-0.5236,
-        range_max=2.0944,
+        range_min=HIP_FLEX_MIN,
+        range_max=HIP_FLEX_MAX,
+        extra_joints=[
+            ("adduct", (0, 0, 1), HIP_ADDUCT_MIN, HIP_ADDUCT_MAX),
+            ("rotate", (0, 1, 0), HIP_ROTATE_MIN, HIP_ROTATE_MAX),
+        ],
     )
     bodies.update(thigh_bodies)
 
@@ -296,8 +369,11 @@ def create_full_body(
         parent_offset_z=-sh_len,
         parent_lateral_x=0,
         coord_prefix="ankle",
-        range_min=-0.7854,
-        range_max=0.7854,
+        range_min=ANKLE_FLEX_MIN,
+        range_max=ANKLE_FLEX_MAX,
+        extra_joints=[
+            ("invert", (0, 0, 1), ANKLE_INVERT_MIN, ANKLE_INVERT_MAX),
+        ],
     )
     bodies.update(foot_bodies)
 

--- a/src/mujoco_models/shared/body/segment_data.py
+++ b/src/mujoco_models/shared/body/segment_data.py
@@ -8,6 +8,8 @@ Extracted from body_model.py to keep modules under the 300-line guideline.
 
 from __future__ import annotations
 
+import math
+
 from mujoco_models.shared.contracts.preconditions import require_positive
 
 # Winter (2009) segment mass fractions and length fractions of total height.
@@ -46,6 +48,46 @@ def total_mass_fraction() -> float:
         multiplier = 2.0 if name in _BILATERAL_SEGMENTS else 1.0
         total += props["mass_frac"] * multiplier
     return total
+
+
+# ---------------------------------------------------------------------------
+# Multi-DOF joint limits (radians)
+# ---------------------------------------------------------------------------
+# Hip (3-DOF): flexion/extension, abduction/adduction, internal/external rotation
+HIP_FLEX_MIN = math.radians(-30)
+HIP_FLEX_MAX = math.radians(120)
+HIP_ADDUCT_MIN = math.radians(-45)
+HIP_ADDUCT_MAX = math.radians(30)
+HIP_ROTATE_MIN = math.radians(-45)
+HIP_ROTATE_MAX = math.radians(45)
+
+# Shoulder (3-DOF): flexion/extension, abduction/adduction, internal/external rotation
+SHOULDER_FLEX_MIN = math.radians(-60)
+SHOULDER_FLEX_MAX = math.radians(180)
+SHOULDER_ADDUCT_MIN = math.radians(-30)
+SHOULDER_ADDUCT_MAX = math.radians(180)
+SHOULDER_ROTATE_MIN = math.radians(-90)
+SHOULDER_ROTATE_MAX = math.radians(90)
+
+# Lumbar (3-DOF): flexion/extension, lateral flexion, axial rotation
+LUMBAR_FLEX_MIN = math.radians(-30)
+LUMBAR_FLEX_MAX = math.radians(45)
+LUMBAR_LATERAL_MIN = math.radians(-30)
+LUMBAR_LATERAL_MAX = math.radians(30)
+LUMBAR_ROTATE_MIN = math.radians(-30)
+LUMBAR_ROTATE_MAX = math.radians(30)
+
+# Ankle (2-DOF): dorsiflexion/plantarflexion, inversion/eversion
+ANKLE_FLEX_MIN = math.radians(-20)
+ANKLE_FLEX_MAX = math.radians(50)
+ANKLE_INVERT_MIN = math.radians(-20)
+ANKLE_INVERT_MAX = math.radians(20)
+
+# Wrist (2-DOF): flexion/extension, radial/ulnar deviation
+WRIST_FLEX_MIN = math.radians(-70)
+WRIST_FLEX_MAX = math.radians(70)
+WRIST_DEVIATE_MIN = math.radians(-20)
+WRIST_DEVIATE_MAX = math.radians(30)
 
 
 def segment_properties(

--- a/tests/integration/test_all_exercises_build.py
+++ b/tests/integration/test_all_exercises_build.py
@@ -150,10 +150,15 @@ class TestAllExercisesBuild:
         "name,builder", ALL_BUILDERS, ids=[n for n, _ in ALL_BUILDERS]
     )
     def test_actuator_sensor_count(self, name: str, builder: Callable[[], str]) -> None:
-        """Every exercise should have exactly 14 position actuators and 14 jointpos sensors."""
+        """Every exercise should have exactly 28 position actuators and 28 jointpos sensors.
+
+        Joint breakdown (multi-DOF upgrade):
+          lumbar (3) + neck (1) + 2*shoulder (3) + 2*elbow (1) + 2*wrist (2)
+          + 2*hip (3) + 2*knee (1) + 2*ankle (2) = 28
+        """
         xml_str = builder()
         root = ET.fromstring(xml_str)
         actuators = root.findall(".//actuator/position")
         sensors = root.findall(".//sensor/jointpos")
-        assert len(actuators) == 14
-        assert len(sensors) == 14
+        assert len(actuators) == 28
+        assert len(sensors) == 28

--- a/tests/integration/test_mujoco_loading.py
+++ b/tests/integration/test_mujoco_loading.py
@@ -51,6 +51,6 @@ class TestMuJoCoLoading:
     def test_model_has_correct_joint_count(self, name: str, builder: Any) -> None:
         xml_str = builder()
         model = mujoco.MjModel.from_xml_string(xml_str)
-        # 14 hinge joints: lumbar, neck, 2 shoulder, 2 elbow, 2 wrist,
-        # 2 hip, 2 knee, 2 ankle
-        assert model.njnt >= 14, f"{name}: expected >= 14 joints, got {model.njnt}"
+        # 28 hinge joints (multi-DOF): lumbar(3), neck(1), 2*shoulder(3),
+        # 2*elbow(1), 2*wrist(2), 2*hip(3), 2*knee(1), 2*ankle(2)
+        assert model.njnt >= 28, f"{name}: expected >= 28 joints, got {model.njnt}"

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -79,10 +79,12 @@ class TestCreateFullBody:
     def test_torso_has_hinge(self, worldbody: ET.Element) -> None:
         bodies = create_full_body(worldbody)
         torso = bodies["torso"]
-        joint = torso.find("joint")
-        assert joint is not None
-        assert joint.get("type") == "hinge"  # type: ignore
-        assert joint.get("name") == "lumbar_flex"  # type: ignore
+        joints = torso.findall("joint")
+        assert len(joints) == 3  # lumbar: flex, lateral, rotate
+        assert joints[0].get("type") == "hinge"  # type: ignore
+        assert joints[0].get("name") == "lumbar_flex"  # type: ignore
+        assert joints[1].get("name") == "lumbar_lateral"  # type: ignore
+        assert joints[2].get("name") == "lumbar_rotate"  # type: ignore
 
     def test_all_bodies_have_inertial(self, worldbody: ET.Element) -> None:
         bodies = create_full_body(worldbody)


### PR DESCRIPTION
## Summary

- **Hip joints** upgraded from 1-DOF to 3-DOF: flexion/extension, abduction/adduction (-45 to 30 deg), internal/external rotation (-45 to 45 deg)
- **Shoulder joints** upgraded from 1-DOF to 3-DOF: flexion/extension (-60 to 180 deg), abduction/adduction (-30 to 180 deg), internal/external rotation (-90 to 90 deg)
- **Lumbar joint** upgraded from 1-DOF to 3-DOF: flexion/extension, lateral flexion (-30 to 30 deg), axial rotation (-30 to 30 deg)
- **Ankle joints** upgraded from 1-DOF to 2-DOF: dorsi/plantarflexion (-20 to 50 deg), inversion/eversion (-20 to 20 deg)
- **Wrist joints** upgraded from 1-DOF to 2-DOF: flexion/extension (-70 to 70 deg), radial/ulnar deviation (-20 to 30 deg)
- Total hinge joints increased from 14 to 28 (actuators and sensors scale accordingly)
- Joint limit constants added to `segment_data.py` for maintainability
- Exercise-specific initial poses updated with sensible defaults for new DOFs (squat hip rotation, bench shoulder adduction, snatch shoulder abduction, clean & jerk shoulder rotation)
- All 311 tests pass

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `pytest tests/ -x --tb=short` -- 311 passed, 10 skipped (MuJoCo C library not installed)
- [ ] Verify MuJoCo loading tests pass in CI (where mujoco is installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)