### PR TITLE
docs: enhance CLAUDE.md with pre-commit, test markers, and Docker sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,34 @@ mypy src --config-file pyproject.toml           # type check
 python3 -m pytest -m "not slow and not requires_mujoco" --cov=src --cov-fail-under=80
 ```
 
+### Pre-commit Hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks run automatically on every commit: ruff lint+fix, ruff format,
+no-wildcard-imports, no-debug-statements, no-print-in-src, prettier (YAML/JSON/MD).
+
+### Test Markers
+
+- `@pytest.mark.slow` -- long-running tests (excluded from default CI run)
+- `@pytest.mark.requires_mujoco` -- needs MuJoCo installed (excluded from default CI run)
+- `@pytest.mark.integration` -- integration tests
+- `@pytest.mark.unit` -- unit tests
+- `@pytest.mark.benchmark` -- performance benchmarks
+
+Tests run in parallel by default (`-n auto --dist loadscope`).
+
+### Docker
+
+```bash
+docker build -t mujoco-models .                 # build runtime image
+docker build --target training -t mujoco-train . # build training image (adds gymnasium, stable-baselines3)
+docker run -it mujoco-models bash                # interactive shell
+```
+
 ## CI Requirements (All Must Pass)
 
 1. `ruff check` -- zero violations


### PR DESCRIPTION
## Summary
- Enhances the existing CLAUDE.md with missing developer onboarding sections
- Adds pre-commit hook setup instructions (ruff, prettier, custom hooks)
- Documents all pytest markers (slow, requires_mujoco, integration, unit, benchmark)
- Adds Docker build and run commands for runtime and training images

Closes #75

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm all documented commands match actual project tooling

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>