### PR TITLE
fix: use exercise-specific grip width

### DIFF
--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -131,7 +131,7 @@ class ExerciseModelBuilder(ABC):
         self,
         equality: ET.Element,
         *,
-        grip_offset: tuple[float, ...] | None = None,
+        grip_width: float | None = None,
     ) -> None:
         """Weld barbell shaft to both hands (DRY helper for subclasses).
 
@@ -139,17 +139,23 @@ class ExerciseModelBuilder(ABC):
         ----------
         equality : ET.Element
             The ``<equality>`` section of the MJCF model.
-        grip_offset : tuple or None
-            Optional 7-element relative pose (x y z qw qx qy qz) for
-            the grip offset from the hand to the barbell shaft.
+        grip_width : float or None
+            Distance from the barbell shaft center to each hand along the X-axis.
+            If None, the initial pose determines the grip width.
         """
-        for side in ("l", "r"):
+        for side, sign in [("l", -1.0), ("r", 1.0)]:
+            relpose: tuple[float, ...] | None = None
+            if grip_width is not None:
+                # Left hand (side="l", sign=-1) is at -X relative to barbell center.
+                # relpose defines barbell center relative to hand, so it's at +X.
+                relpose = (-sign * grip_width, 0, 0, 1, 0, 0, 0)
+                
             add_weld_constraint(
                 equality,
                 name=f"barbell_to_hand_{side}",
                 body1=f"hand_{side}",
                 body2="barbell_shaft",
-                relpose=grip_offset,
+                relpose=relpose,
             )
 
     def build(self) -> str:

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -149,7 +149,7 @@ class ExerciseModelBuilder(ABC):
                 # Left hand (side="l", sign=-1) is at -X relative to barbell center.
                 # relpose defines barbell center relative to hand, so it's at +X.
                 relpose = (-sign * grip_width, 0, 0, 1, 0, 0, 0)
-                
+
             add_weld_constraint(
                 equality,
                 name=f"barbell_to_hand_{side}",

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -57,7 +57,7 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         The grip is approximately shoulder-width (~0.40 m from center
         on each side for a standard grip).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_width=0.40)
 
     def _post_worldbody_hook(self, worldbody: ET.Element, equality: ET.Element) -> None:
         """Add bench body and weld pelvis to it."""

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -68,7 +68,7 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
 
         Clean grip: approximately shoulder width, ~0.25 m from shaft center.
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_width=0.25)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, clean grip, hip hinge.

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -57,7 +57,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
         Grip is slightly outside the knees (~0.22 m from center).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_width=0.22)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set the starting position: deep hip hinge, knees flexed.

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -61,7 +61,7 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         Snatch grip is approximately 0.55-0.60 m from shaft center
         on each side (~1.5x shoulder width).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_width=0.60)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, wide grip, deep hip hinge.


### PR DESCRIPTION
Fixes #56 by modifying _attach_barbell_to_hands to accept a symmetric grip_width and correctly passing the width for each specific exercise type.