### PR TITLE
fix: A-N Assessment remediation — DbC, LoD, documentation (issue #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-03-30
+
+### Fixed (A-N Assessment Remediation — issue #90)
+
+- **DbC**: Added precondition guards (`n_frames >= 2`, non-empty phases) to `interpolate_phases()` in `trajectory_optimizer.py`.
+- **DbC**: Added shape and size validation to `point_in_polygon()` in `polygon_geometry.py`.
+- **LoD**: Broke `Path(__file__).resolve().parent.parent` chain in `setup_dev.py` into named `_SCRIPT_DIR` and `PROJECT_ROOT` intermediates.
+- **Documentation**: Added missing docstrings to `main()` in `setup_dev.py` and `generate_all_models.py`.
+- **Documentation**: Added docstrings to `ExerciseModelBuilder.__init__()`, `BarbellSpec.__post_init__()`, and `BodyModelSpec.__post_init__()`.
+- **Documentation**: Added docstrings to `shaft_radius` and `sleeve_radius` properties in `BarbellSpec`.
+- **Documentation**: Added docstrings to `exercise_name` property in all 7 exercise model builders.
+- **Documentation**: Added docstring to `_rad()` helper in `shared/parity/standard.py`.
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/examples/generate_all_models.py
+++ b/examples/generate_all_models.py
@@ -18,6 +18,11 @@ from mujoco_models.shared.body import BodyModelSpec
 
 
 def main() -> None:
+    """Generate MJCF XML files for all registered exercise models.
+
+    Parses command-line arguments and writes one XML file per exercise
+    to the configured output directory.
+    """
     parser = argparse.ArgumentParser(description="Generate all exercise models.")
     parser.add_argument(
         "--output-dir",

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -6,11 +6,21 @@ import sys
 from pathlib import Path
 
 MIN_PYTHON = (3, 10)
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_DIR: Path = Path(__file__).resolve().parent
+PROJECT_ROOT: Path = _SCRIPT_DIR.parent
 VENDOR_UD_TOOLS = PROJECT_ROOT / "vendor" / "ud-tools"
 
 
 def main() -> None:
+    """Bootstrap the developer environment for MuJoCo_Models.
+
+    Checks the Python version, initialises git submodules, installs the
+    package in editable mode, and installs the vendored ud-tools dependency.
+
+    Raises:
+        SystemExit: If the Python version is below the minimum or if
+            vendor/ud-tools is not found.
+    """
     if sys.version_info < MIN_PYTHON:
         sys.exit(f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ is required.")
 

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -96,6 +96,13 @@ class ExerciseModelBuilder(ABC):
     """
 
     def __init__(self, config: ExerciseConfig | None = None) -> None:
+        """Initialize with an optional exercise configuration.
+
+        Args:
+            config: Exercise configuration. Uses default ``ExerciseConfig``
+                (50th-percentile male anthropometrics, men's Olympic barbell)
+                if ``None``.
+        """
         self.config = config or ExerciseConfig()
 
     @property

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -44,6 +44,7 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the bench press model."""
         return "bench_press"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -56,6 +56,7 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the clean and jerk model."""
         return "clean_and_jerk"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -45,6 +45,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the deadlift model."""
         return "deadlift"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/gait/gait_model.py
+++ b/src/mujoco_models/exercises/gait/gait_model.py
@@ -50,6 +50,7 @@ class GaitModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the gait model."""
         return "gait"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -53,6 +53,7 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the sit-to-stand model."""
         return "sit_to_stand"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -48,6 +48,7 @@ class SnatchModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the snatch model."""
         return "snatch"
 
     def attach_barbell(

--- a/src/mujoco_models/exercises/squat/squat_model.py
+++ b/src/mujoco_models/exercises/squat/squat_model.py
@@ -39,6 +39,7 @@ class SquatModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the back squat model."""
         return "back_squat"
 
     def attach_barbell(

--- a/src/mujoco_models/optimization/polygon_geometry.py
+++ b/src/mujoco_models/optimization/polygon_geometry.py
@@ -18,7 +18,14 @@ def point_in_polygon(point: np.ndarray, polygon: np.ndarray) -> bool:
 
     Returns:
         True if the point is inside the polygon.
+
+    Raises:
+        ValueError: If point is not shape (2,) or polygon has fewer than 3 vertices.
     """
+    if point.shape != (2,):
+        raise ValueError(f"point must have shape (2,), got {point.shape}")
+    if len(polygon) < 3:
+        raise ValueError(f"polygon must have at least 3 vertices, got {len(polygon)}")
     n = len(polygon)
     inside = False
     px, py = point[0], point[1]

--- a/src/mujoco_models/optimization/trajectory_optimizer.py
+++ b/src/mujoco_models/optimization/trajectory_optimizer.py
@@ -143,7 +143,13 @@ def interpolate_phases(
     Returns:
         Array of shape ``(n_frames, n_joints)`` with linearly
         interpolated joint angles.  Joint ordering is alphabetical.
+    Raises:
+        ValueError: If n_frames < 2 or objective has no phases.
     """
+    if n_frames < 2:
+        raise ValueError(f"n_frames must be >= 2, got {n_frames}")
+    if not objective.phases:
+        raise ValueError("objective must have at least one phase")
     joint_names = objective.joint_names
     n_joints = len(joint_names)
 

--- a/src/mujoco_models/shared/barbell/barbell_model.py
+++ b/src/mujoco_models/shared/barbell/barbell_model.py
@@ -49,6 +49,7 @@ class BarbellSpec:
     plate_mass_per_side: float = 0.0
 
     def __post_init__(self) -> None:
+        """Validate barbell specification dimensions and masses."""
         require_positive(self.total_length, "total_length")
         require_positive(self.shaft_length, "shaft_length")
         require_positive(self.shaft_diameter, "shaft_diameter")
@@ -68,10 +69,12 @@ class BarbellSpec:
 
     @property
     def shaft_radius(self) -> float:
+        """Shaft radius in meters (half the shaft diameter)."""
         return self.shaft_diameter / 2.0
 
     @property
     def sleeve_radius(self) -> float:
+        """Sleeve radius in meters (half the sleeve diameter)."""
         return self.sleeve_diameter / 2.0
 
     @property

--- a/src/mujoco_models/shared/body/body_model.py
+++ b/src/mujoco_models/shared/body/body_model.py
@@ -93,6 +93,7 @@ class BodyModelSpec:
     height: float = 1.75
 
     def __post_init__(self) -> None:
+        """Validate that total_mass and height are strictly positive."""
         require_positive(self.total_mass, "total_mass")
         require_positive(self.height, "height")
 

--- a/src/mujoco_models/shared/parity/standard.py
+++ b/src/mujoco_models/shared/parity/standard.py
@@ -11,6 +11,7 @@ import math
 
 
 def _rad(deg: float) -> float:
+    """Convert degrees to radians."""
     return math.radians(deg)
 
 


### PR DESCRIPTION
## Summary

Addresses the [A-N Assessment] Comprehensive Code Quality & Architecture Remediation findings for MuJoCo_Models.

| Category | Fix Description |
|----------|-----------------|
| DbC | Added precondition guards (`n_frames >= 2`, non-empty phases) to `interpolate_phases()` in `trajectory_optimizer.py` |
| DbC | Added shape/size validation to `point_in_polygon()` in `polygon_geometry.py` |
| LoD | Broke `Path(__file__).resolve().parent.parent` chain in `setup_dev.py` into named intermediates |
| Documentation | Added docstrings to `main()` in `setup_dev.py` and `generate_all_models.py` |
| Documentation | Added docstrings to `ExerciseModelBuilder.__init__()`, `BarbellSpec.__post_init__()`, `BodyModelSpec.__post_init__()` |
| Documentation | Added docstrings to `shaft_radius`/`sleeve_radius` properties in `BarbellSpec` |
| Documentation | Added docstrings to `exercise_name` property in all 7 exercise model builders |
| Documentation | Added docstring to `_rad()` helper in `shared/parity/standard.py` |

## Test plan
- [x] `ruff check` passes (zero violations)
- [x] `ruff format --check` passes (zero diffs)
- [x] `mypy src` passes (zero errors)
- [x] 585 tests pass
- [x] CHANGELOG.md updated with remediation entry

Closes #90