### PR TITLE
ci: self-hosted runner with cloud fallback

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -24,8 +24,32 @@ permissions:
   contents: read
 
 jobs:
-  quality-gate:
+
+  # ── Dispatcher: route to self-hosted if available ──────────────────────────
+  pick-runner:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      runner: ${{ steps.check.outputs.runner }}
+    steps:
+      - name: Check for self-hosted runner
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
+            --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \
+            2>/dev/null || echo "0")
+          if [[ "$ONLINE" -gt 0 ]]; then
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
+            echo "Self-hosted runner online — routing locally"
+          else
+            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "No self-hosted runner — using GitHub-hosted"
+          fi
+  quality-gate:
+    needs: pick-runner
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -68,8 +92,8 @@ jobs:
           bandit -r src/ -ll -ii --format txt
 
   tests:
-    needs: quality-gate
-    runs-on: ubuntu-latest
+    needs: [pick-runner, quality-gate]
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
## Self-Hosted Runner Migration

Adds a `pick-runner` dispatcher job to all workflows that:
- Checks if a self-hosted runner (label: `d-sorg-fleet`) is online
- Routes jobs to local runner when available (FREE)
- Falls back to `ubuntu-latest` when offline (uses Actions minutes)

### No breaking changes
All workflows continue to work exactly as before when the self-hosted runner is offline. This is purely additive.

### Runners
- 3x parallel runners on ControlTower (WSL2)
- Labels: `self-hosted, Linux, X64, d-sorg-fleet, d-sorg-fleet-4core`
