### PR TITLE
ci: route core test and quality jobs to self-hosted first

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -24,8 +24,6 @@ permissions:
   contents: read
 
 jobs:
-
-  # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -36,19 +34,8 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-        run: |
-          ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
-            --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \
-            2>/dev/null || echo "0")
-          if [[ "$ONLINE" -gt 0 ]]; then
-            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "Self-hosted runner online — routing locally"
-          else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
-          fi
+        run: "ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \\\n  --jq '[.runners[] | select(.status == \"online\") | select(.labels[].name == \"d-sorg-fleet\")] | length' \\\n  2>/dev/null || echo \"0\")\nif [[ \"$ONLINE\" -gt 0 ]]; then\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"Self-hosted runner online — routing locally\"\nelse\n  echo \"runner=ubuntu-latest\" >> $GITHUB_OUTPUT\n  echo \"No self-hosted runner — using GitHub-hosted\"\nfi"
   quality-gate:
-    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
@@ -56,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v6
-        with: { python-version: "3.11" }
+        with: {python-version: "3.11"}
       - run: pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7
 
       - name: Lint
@@ -91,8 +78,11 @@ jobs:
         run: |
           bandit -r src/ -ll -ii --format txt
 
+    needs: pick-runner
   tests:
-    needs: [pick-runner, quality-gate]
+    needs:
+      - pick-runner
+      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
Routes core CI test and quality jobs through the self-hosted runner dispatcher with GitHub-hosted fallback.

Changes include:
- add or reuse `pick-runner`
- run core test/quality jobs on `${{ needs.pick-runner.outputs.runner }}`
- make common Linux dependency/bootstrap steps tolerate self-hosted runners without passwordless `sudo`
- prefer `xvfb-run -a` to avoid display collisions on shared self-hosted runners
