### PR TITLE
[codex] add LoD accessor properties on ExerciseModelBuilder

### DIFF
--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -54,6 +54,26 @@ class ExerciseModelBuilder(ABC):
         self.config = config or ExerciseConfig()
 
     @property
+    def body_spec(self) -> BodyModelSpec:
+        """Forward to the configured body specification."""
+        return self.config.body_spec
+
+    @property
+    def barbell_spec(self) -> BarbellSpec:
+        """Forward to the configured barbell specification."""
+        return self.config.barbell_spec
+
+    @property
+    def gravity(self) -> tuple[float, float, float]:
+        """Forward to the configured gravity vector."""
+        return self.config.gravity
+
+    @property
+    def grip_offset(self) -> tuple[float, ...] | None:
+        """Optional grip offset for subclasses that need a custom weld pose."""
+        return None
+
+    @property
     @abstractmethod
     def exercise_name(self) -> str:
         """Human-readable exercise name used in the model XML."""
@@ -118,7 +138,7 @@ class ExerciseModelBuilder(ABC):
         root = ET.Element("mujoco", model=self.exercise_name)
 
         # Option: gravity and timestep
-        g = self.config.gravity
+        g = self.gravity
         ET.SubElement(
             root,
             "option",
@@ -151,11 +171,11 @@ class ExerciseModelBuilder(ABC):
         equality = ET.SubElement(root, "equality")
 
         # Build body
-        body_bodies = create_full_body(worldbody, self.config.body_spec)
+        body_bodies = create_full_body(worldbody, self.body_spec)
 
         # Build barbell
         barbell_bodies = create_barbell_bodies(
-            worldbody, equality, self.config.barbell_spec
+            worldbody, equality, self.barbell_spec
         )
 
         # Exercise-specific attachment

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -55,7 +55,7 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         The grip is approximately shoulder-width (~0.40 m from center
         on each side for a standard grip).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_offset=self.grip_offset)
 
     def _post_worldbody_hook(self, worldbody: ET.Element, equality: ET.Element) -> None:
         """Add bench body and weld pelvis to it."""

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -66,7 +66,7 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
 
         Clean grip: approximately shoulder width, ~0.25 m from shaft center.
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_offset=self.grip_offset)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, clean grip, hip hinge.

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -57,7 +57,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
         Grip is slightly outside the knees (~0.22 m from center).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_offset=self.grip_offset)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set the starting position: deep hip hinge, knees flexed.

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -59,7 +59,7 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         Snatch grip is approximately 0.55-0.60 m from shaft center
         on each side (~1.5x shoulder width).
         """
-        self._attach_barbell_to_hands(equality)
+        self._attach_barbell_to_hands(equality, grip_offset=self.grip_offset)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set starting position: bar on floor, wide grip, deep hip hinge.

--- a/tests/unit/exercises/bench_press/test_bench_press_model.py
+++ b/tests/unit/exercises/bench_press/test_bench_press_model.py
@@ -107,4 +107,4 @@ class TestBenchPressModelBuilder:
 
     def test_default_config_gravity(self) -> None:
         builder = BenchPressModelBuilder()
-        assert builder.config.gravity[2] < 0
+        assert builder.gravity[2] < 0

--- a/tests/unit/exercises/clean_and_jerk/test_clean_and_jerk_model.py
+++ b/tests/unit/exercises/clean_and_jerk/test_clean_and_jerk_model.py
@@ -55,4 +55,4 @@ class TestCleanAndJerkModelBuilder:
 
     def test_default_gravity_z_up(self) -> None:
         builder = CleanAndJerkModelBuilder()
-        assert builder.config.gravity == (0.0, 0.0, -9.80665)
+        assert builder.gravity == (0.0, 0.0, -9.80665)

--- a/tests/unit/exercises/deadlift/test_deadlift_model.py
+++ b/tests/unit/exercises/deadlift/test_deadlift_model.py
@@ -87,4 +87,4 @@ class TestDeadliftModelBuilder:
 
     def test_default_plate_mass(self) -> None:
         builder = DeadliftModelBuilder()
-        assert builder.config.barbell_spec.plate_mass_per_side == 0.0
+        assert builder.barbell_spec.plate_mass_per_side == 0.0

--- a/tests/unit/exercises/snatch/test_snatch_model.py
+++ b/tests/unit/exercises/snatch/test_snatch_model.py
@@ -55,7 +55,7 @@ class TestSnatchModelBuilder:
 
     def test_default_config_z_up_gravity(self) -> None:
         builder = SnatchModelBuilder()
-        gx, gy, gz = builder.config.gravity
+        gx, gy, gz = builder.gravity
         assert gx == 0.0
         assert gy == 0.0
         assert gz < 0

--- a/tests/unit/exercises/squat/test_squat_model.py
+++ b/tests/unit/exercises/squat/test_squat_model.py
@@ -51,7 +51,7 @@ class TestSquatModelBuilder:
 
     def test_default_config(self) -> None:
         builder = SquatModelBuilder()
-        assert builder.config.gravity == (0.0, 0.0, -9.80665)
+        assert builder.gravity == (0.0, 0.0, -9.80665)
 
     def test_attach_barbell_adds_weld(self) -> None:
         builder = SquatModelBuilder()

--- a/tests/unit/exercises/test_base.py
+++ b/tests/unit/exercises/test_base.py
@@ -1,0 +1,94 @@
+"""Regression tests for the shared exercise builder base class."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mujoco_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from mujoco_models.shared.barbell import BarbellSpec
+from mujoco_models.shared.body import BodyModelSpec, segment_properties
+
+
+class ForwardingBuilder(ExerciseModelBuilder):
+    @property
+    def exercise_name(self) -> str:
+        return "forwarding_builder"
+
+    def attach_barbell(
+        self,
+        equality: ET.Element,
+        body_bodies: dict[str, ET.Element],
+        barbell_bodies: dict[str, ET.Element],
+    ) -> None:
+        self._attach_barbell_to_hands(equality, grip_offset=self.grip_offset)
+
+    def set_initial_pose(self, worldbody: ET.Element) -> None:
+        return None
+
+
+class OverriddenAccessorBuilder(ForwardingBuilder):
+    def __init__(self) -> None:
+        super().__init__(
+            ExerciseConfig(
+                body_spec=BodyModelSpec(total_mass=90.0, height=1.82),
+                barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=25.0),
+                gravity=(1.0, 2.0, -3.0),
+            )
+        )
+        self._body_spec = BodyModelSpec(total_mass=95.0, height=1.90)
+        self._barbell_spec = BarbellSpec.womens_olympic(plate_mass_per_side=10.0)
+        self._gravity = (0.5, -0.25, -4.5)
+        self._grip_offset = (0.010, 0.020, 0.030, 1.0, 0.0, 0.0, 0.0)
+
+    @property
+    def body_spec(self) -> BodyModelSpec:
+        return self._body_spec
+
+    @property
+    def barbell_spec(self) -> BarbellSpec:
+        return self._barbell_spec
+
+    @property
+    def gravity(self) -> tuple[float, float, float]:
+        return self._gravity
+
+    @property
+    def grip_offset(self) -> tuple[float, ...] | None:
+        return self._grip_offset
+
+
+class TestExerciseModelBuilderAccessors:
+    def test_accessors_forward_config(self) -> None:
+        builder = ForwardingBuilder(ExerciseConfig())
+        assert builder.body_spec == builder.config.body_spec
+        assert builder.barbell_spec == builder.config.barbell_spec
+        assert builder.gravity == builder.config.gravity
+        assert builder.grip_offset is None
+
+    def test_build_uses_accessor_overrides(self) -> None:
+        builder = OverriddenAccessorBuilder()
+        xml_str = builder.build()
+        root = ET.fromstring(xml_str)
+
+        option = root.find("option")
+        assert option is not None
+        assert option.get("gravity") == "0.500000 -0.250000 -4.500000"
+
+        pelvis = root.find(".//body[@name='pelvis']/inertial")
+        assert pelvis is not None
+        expected_pelvis_mass, _, _ = segment_properties(
+            builder.body_spec.total_mass, builder.body_spec.height, "pelvis"
+        )
+        assert float(pelvis.get("mass")) == pytest.approx(expected_pelvis_mass)  # type: ignore[arg-type]
+
+        barbell_shaft = root.find(".//body[@name='barbell_shaft']/inertial")
+        assert barbell_shaft is not None
+        assert float(barbell_shaft.get("mass")) == pytest.approx(
+            builder.barbell_spec.shaft_mass
+        )  # type: ignore[arg-type]
+
+        weld = root.find(".//weld[@name='barbell_to_hand_l']")
+        assert weld is not None
+        assert weld.get("relpose") == "0.010000 0.020000 0.030000 1.000000 0.000000 0.000000 0.000000"


### PR DESCRIPTION
## What changed
- Added forwarding accessors on `ExerciseModelBuilder` for `body_spec`, `barbell_spec`, `gravity`, and `grip_offset`.
- Switched the shared build path to use those accessors instead of reaching through `self.config` directly.
- Updated the exercise builders to route barbell attachment through the new `grip_offset` accessor.
- Added regression tests that verify the accessors forward config values and that overridden accessors affect the built MJCF.

## Why
This removes the extra config hop from the shared builder flow and keeps the exercise builders aligned with the Law of Demeter cleanup described in #119.

## Validation
- `ruff check ...` on the touched source and test files
- `pytest -q tests/unit/exercises tests/integration/test_all_exercises_build.py`

Closes #119
