### PR TITLE
test: add missing tests for inverse_kinematics and polygon_geometry

### DIFF
--- a/tests/unit/optimization/test_inverse_kinematics.py
+++ b/tests/unit/optimization/test_inverse_kinematics.py
@@ -1,0 +1,136 @@
+"""Tests for the IK keyframe generator.
+
+Covers ``solve_ik_keyframes`` for reachable targets, convergence through
+phase interpolation, boundary values, and DbC failures on invalid input.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mujoco_models.optimization.exercise_objectives import (
+    EXERCISE_OBJECTIVES,
+)
+from mujoco_models.optimization.inverse_kinematics import (
+    solve_ik_keyframes,
+)
+
+KNOWN_EXERCISES = [
+    "squat",
+    "deadlift",
+    "bench_press",
+    "snatch",
+    "clean_and_jerk",
+    "gait",
+    "sit_to_stand",
+]
+
+
+class TestSolveIKKeyframesShape:
+    """Output shape must match (n_frames, n_joints)."""
+
+    @pytest.mark.parametrize("name", KNOWN_EXERCISES)
+    def test_default_frame_count_shape(self, name: str) -> None:
+        keyframes = solve_ik_keyframes(name)
+        n_joints = len(EXERCISE_OBJECTIVES[name].joint_names)
+        assert keyframes.shape == (50, n_joints)
+
+    @pytest.mark.parametrize("n_frames", [2, 5, 50, 200])
+    def test_custom_frame_count_shape(self, n_frames: int) -> None:
+        keyframes = solve_ik_keyframes("squat", n_frames=n_frames)
+        n_joints = len(EXERCISE_OBJECTIVES["squat"].joint_names)
+        assert keyframes.shape == (n_frames, n_joints)
+
+    def test_returns_numpy_array(self) -> None:
+        keyframes = solve_ik_keyframes("squat", n_frames=3)
+        assert isinstance(keyframes, np.ndarray)
+        assert keyframes.dtype.kind == "f"
+
+
+class TestSolveIKKeyframesInterpolation:
+    """Endpoints must match the first/last phase targets."""
+
+    def test_first_frame_matches_first_phase(self) -> None:
+        objective = EXERCISE_OBJECTIVES["squat"]
+        joint_names = objective.joint_names
+        first_phase = objective.phases[0]
+
+        keyframes = solve_ik_keyframes("squat", n_frames=10)
+
+        expected = np.array(
+            [first_phase.target_joints.get(name, 0.0) for name in joint_names]
+        )
+        assert keyframes[0] == pytest.approx(expected)
+
+    def test_last_frame_matches_last_phase(self) -> None:
+        objective = EXERCISE_OBJECTIVES["squat"]
+        joint_names = objective.joint_names
+        last_phase = objective.phases[-1]
+
+        keyframes = solve_ik_keyframes("squat", n_frames=10)
+
+        expected = np.array(
+            [last_phase.target_joints.get(name, 0.0) for name in joint_names]
+        )
+        assert keyframes[-1] == pytest.approx(expected)
+
+    def test_interpolation_is_smooth(self) -> None:
+        """Adjacent keyframes should differ by a bounded step."""
+        keyframes = solve_ik_keyframes("squat", n_frames=50)
+        diffs = np.abs(np.diff(keyframes, axis=0))
+        # No single step should exceed the full span of any joint.
+        joint_spans = keyframes.max(axis=0) - keyframes.min(axis=0)
+        per_joint_max_step = diffs.max(axis=0)
+        # Each per-joint step is at most the joint's full span.
+        assert np.all(per_joint_max_step <= joint_spans + 1e-9)
+
+    def test_minimum_frame_count_returns_endpoints(self) -> None:
+        """With n_frames=2 output is [first_phase, last_phase]."""
+        objective = EXERCISE_OBJECTIVES["squat"]
+        joint_names = objective.joint_names
+        keyframes = solve_ik_keyframes("squat", n_frames=2)
+
+        expected_first = np.array(
+            [objective.phases[0].target_joints.get(n, 0.0) for n in joint_names]
+        )
+        expected_last = np.array(
+            [objective.phases[-1].target_joints.get(n, 0.0) for n in joint_names]
+        )
+        assert keyframes[0] == pytest.approx(expected_first)
+        assert keyframes[1] == pytest.approx(expected_last)
+
+    def test_deterministic_output(self) -> None:
+        """Calling twice must produce identical arrays."""
+        a = solve_ik_keyframes("deadlift", n_frames=17)
+        b = solve_ik_keyframes("deadlift", n_frames=17)
+        assert np.array_equal(a, b)
+
+
+class TestSolveIKKeyframesJointOrder:
+    """Output columns must follow sorted joint_names order."""
+
+    def test_joint_order_is_sorted(self) -> None:
+        objective = EXERCISE_OBJECTIVES["squat"]
+        joint_names = objective.joint_names
+        assert joint_names == sorted(joint_names)
+
+        keyframes = solve_ik_keyframes("squat", n_frames=3)
+        assert keyframes.shape[1] == len(joint_names)
+
+
+class TestSolveIKKeyframesDbC:
+    """Design-by-contract: reject invalid inputs with ValueError."""
+
+    def test_unknown_exercise_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown exercise"):
+            solve_ik_keyframes("nonexistent_exercise")
+
+    @pytest.mark.parametrize("n_frames", [0, 1, -5])
+    def test_too_few_frames_raises(self, n_frames: int) -> None:
+        with pytest.raises(ValueError, match="n_frames must be >= 2"):
+            solve_ik_keyframes("squat", n_frames=n_frames)
+
+    def test_empty_exercise_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown exercise"):
+            solve_ik_keyframes("", n_frames=5)

--- a/tests/unit/optimization/test_polygon_geometry.py
+++ b/tests/unit/optimization/test_polygon_geometry.py
@@ -1,0 +1,112 @@
+"""Tests for 2D polygon geometry helpers.
+
+Covers ``point_in_polygon`` and ``squared_distance_to_polygon`` with
+happy-path geometries, boundary cases, and DbC failures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mujoco_models.optimization.polygon_geometry import (
+    point_in_polygon,
+    squared_distance_to_polygon,
+)
+
+
+def _unit_square() -> np.ndarray:
+    """Axis-aligned unit square with vertices in CCW order."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+        ]
+    )
+
+
+def _triangle() -> np.ndarray:
+    """Right triangle with legs of length 2."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [0.0, 2.0],
+        ]
+    )
+
+
+class TestPointInPolygon:
+    """Ray-casting point-in-polygon behavior."""
+
+    def test_center_of_square_is_inside(self) -> None:
+        assert point_in_polygon(np.array([0.5, 0.5]), _unit_square()) is True
+
+    def test_point_far_outside_square(self) -> None:
+        assert point_in_polygon(np.array([5.0, 5.0]), _unit_square()) is False
+
+    def test_negative_coordinate_outside(self) -> None:
+        assert point_in_polygon(np.array([-0.1, 0.5]), _unit_square()) is False
+
+    def test_triangle_interior(self) -> None:
+        # Centroid of the (0,0),(2,0),(0,2) triangle is (2/3, 2/3).
+        assert point_in_polygon(np.array([2.0 / 3.0, 2.0 / 3.0]), _triangle()) is True
+
+    def test_triangle_outside_hypotenuse(self) -> None:
+        # (1.5, 1.5) lies on the far side of the hypotenuse x + y = 2.
+        assert point_in_polygon(np.array([1.5, 1.5]), _triangle()) is False
+
+
+class TestPointInPolygonDbC:
+    """Contract violations raise ValueError."""
+
+    def test_wrong_point_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"point must have shape"):
+            point_in_polygon(np.array([0.0, 0.0, 0.0]), _unit_square())
+
+    def test_polygon_with_two_vertices_raises(self) -> None:
+        bad = np.array([[0.0, 0.0], [1.0, 0.0]])
+        with pytest.raises(ValueError, match=r"at least 3 vertices"):
+            point_in_polygon(np.array([0.5, 0.5]), bad)
+
+    def test_empty_polygon_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"at least 3 vertices"):
+            point_in_polygon(np.array([0.0, 0.0]), np.empty((0, 2)))
+
+
+class TestSquaredDistanceToPolygon:
+    """Nearest-edge squared distance computations."""
+
+    def test_distance_to_edge_outside(self) -> None:
+        # Point (2, 0.5) is 1.0 away from the right edge of the unit square.
+        dist_sq = squared_distance_to_polygon(np.array([2.0, 0.5]), _unit_square())
+        assert dist_sq == pytest.approx(1.0)
+
+    def test_distance_to_corner(self) -> None:
+        # Point (-1, -1) is sqrt(2) away from corner (0, 0): squared = 2.
+        dist_sq = squared_distance_to_polygon(np.array([-1.0, -1.0]), _unit_square())
+        assert dist_sq == pytest.approx(2.0)
+
+    def test_zero_distance_on_edge(self) -> None:
+        # Midpoint of the bottom edge lies exactly on the boundary.
+        dist_sq = squared_distance_to_polygon(np.array([0.5, 0.0]), _unit_square())
+        assert dist_sq == pytest.approx(0.0, abs=1e-12)
+
+    def test_interior_point_gives_small_distance(self) -> None:
+        # Center of unit square is 0.5 from each edge: squared = 0.25.
+        dist_sq = squared_distance_to_polygon(np.array([0.5, 0.5]), _unit_square())
+        assert dist_sq == pytest.approx(0.25)
+
+    def test_distance_is_nonnegative(self) -> None:
+        for px, py in [(0.1, 0.1), (-2.0, 3.0), (0.5, 0.5), (1.0, 1.0)]:
+            dist_sq = squared_distance_to_polygon(np.array([px, py]), _unit_square())
+            assert dist_sq >= 0.0
+
+    def test_symmetric_across_square(self) -> None:
+        """By symmetry, points reflected over center have equal distance."""
+        sq = _unit_square()
+        d1 = squared_distance_to_polygon(np.array([2.0, 0.5]), sq)
+        d2 = squared_distance_to_polygon(np.array([-1.0, 0.5]), sq)
+        assert d1 == pytest.approx(d2)


### PR DESCRIPTION
## Summary
- Adds `tests/unit/optimization/test_inverse_kinematics.py` covering `solve_ik_keyframes` (shape, interpolation, determinism, DbC failures).
- Adds `tests/unit/optimization/test_polygon_geometry.py` covering `point_in_polygon` and `squared_distance_to_polygon` (happy path, boundary, DbC failures).
- Test-only change; no src/ modifications.

Fixes #120

## Test plan
- [ ] CI: ruff check passes on tests/
- [ ] CI: ruff format --check passes on tests/
- [ ] CI: pytest collects and runs the new tests on all Python matrix versions

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>