### PR TITLE
refactor: adopt uses_barbell flag and remove zero-mass hack (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-04-11
+
+### Refactored (issue #118)
+
+- **Reusability**: Added `uses_barbell` property to `ExerciseModelBuilder` (default `True`) so `build()` can skip barbell construction and attachment when an exercise has no barbell.
+- **Code smells**: Removed the zero-mass `BarbellSpec.mens_olympic(plate_mass_per_side=0.0)` hack from `build_gait_model()` and `build_sit_to_stand_model()`. Their builders now override `uses_barbell = False`, and the barbell bodies/welds are omitted entirely rather than materialised with zero plate mass.
+
 ## [Unreleased] - 2026-03-30
 
 ### Fixed (A-N Assessment Remediation — issue #90)

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,7 +64,7 @@ Model generation follows the same pipeline across exercises:
 3. Create the `<mujoco>` root with options, compiler settings, and defaults.
 4. Build the `worldbody` and `equality` sections.
 5. Assemble the full body through `create_full_body()`.
-6. Assemble the barbell through `create_barbell_bodies()`.
+6. Assemble the barbell through `create_barbell_bodies()` when the exercise builder's `uses_barbell` property is `True` (gait and sit-to-stand opt out).
 7. Apply the exercise-specific barbell attachment and pose hooks.
 8. Add contact exclusions, actuators, sensors, and keyframes.
 9. Serialize and validate the MJCF XML.

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -130,6 +130,16 @@ class ExerciseModelBuilder(ABC):
     def exercise_name(self) -> str:
         """Human-readable exercise name used in the model XML."""
 
+    @property
+    def uses_barbell(self) -> bool:
+        """Return True if this exercise builds and attaches a barbell.
+
+        Override in subclasses (e.g. gait, sit-to-stand) that do not
+        use a barbell so that barbell bodies, welds, and attachment
+        logic are skipped entirely rather than created with zero mass.
+        """
+        return True
+
     @abstractmethod
     def attach_barbell(
         self,
@@ -325,12 +335,17 @@ class ExerciseModelBuilder(ABC):
         # Step 3: equality constraints section
         equality = ET.SubElement(root, "equality")
 
-        # Step 4: body and barbell
+        # Step 4: body and (optionally) barbell
         body_bodies = create_full_body(worldbody, self.body_spec)
-        barbell_bodies = create_barbell_bodies(worldbody, equality, self.barbell_spec)
+        barbell_bodies: dict[str, ET.Element] = {}
+        if self.uses_barbell:
+            barbell_bodies = create_barbell_bodies(
+                worldbody, equality, self.barbell_spec
+            )
 
         # Step 5: exercise-specific attachment and hook
-        self.attach_barbell(equality, body_bodies, barbell_bodies)
+        if self.uses_barbell:
+            self.attach_barbell(equality, body_bodies, barbell_bodies)
         self._post_worldbody_hook(worldbody, equality)
 
         # Step 6: contact exclusions

--- a/src/mujoco_models/exercises/gait/gait_model.py
+++ b/src/mujoco_models/exercises/gait/gait_model.py
@@ -53,13 +53,22 @@ class GaitModelBuilder(ExerciseModelBuilder):
         """Return the canonical exercise name for the gait model."""
         return "gait"
 
+    @property
+    def uses_barbell(self) -> bool:
+        """Gait is a bodyweight movement -- no barbell is built."""
+        return False
+
     def attach_barbell(
         self,
         equality: ET.Element,
         body_bodies: dict[str, ET.Element],
         barbell_bodies: dict[str, ET.Element],
     ) -> None:
-        """No barbell for gait analysis -- intentional no-op."""
+        """No barbell for gait analysis -- intentional no-op.
+
+        Kept to satisfy the abstract contract; never invoked because
+        ``uses_barbell`` is ``False``.
+        """
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set right heel strike pose with asymmetric limb angles.
@@ -83,10 +92,7 @@ def build_gait_model(body_mass: float = 80.0, height: float = 1.75) -> str:
 
     Default: 80 kg person, 1.75 m tall, no barbell.
     """
-    from mujoco_models.shared.barbell import BarbellSpec
-
     config = ExerciseConfig(
         body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=0.0),
     )
     return GaitModelBuilder(config).build()

--- a/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -56,13 +56,22 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
         """Return the canonical exercise name for the sit-to-stand model."""
         return "sit_to_stand"
 
+    @property
+    def uses_barbell(self) -> bool:
+        """Sit-to-stand is a bodyweight movement -- no barbell is built."""
+        return False
+
     def attach_barbell(
         self,
         equality: ET.Element,
         body_bodies: dict[str, ET.Element],
         barbell_bodies: dict[str, ET.Element],
     ) -> None:
-        """No barbell for sit-to-stand -- intentional no-op."""
+        """No barbell for sit-to-stand -- intentional no-op.
+
+        Kept to satisfy the abstract contract; never invoked because
+        ``uses_barbell`` is ``False``.
+        """
 
     def _post_worldbody_hook(self, worldbody: ET.Element, equality: ET.Element) -> None:
         """Add a chair body welded to the ground plane."""
@@ -132,10 +141,7 @@ def build_sit_to_stand_model(body_mass: float = 80.0, height: float = 1.75) -> s
 
     Default: 80 kg person, 1.75 m tall, standard chair height.
     """
-    from mujoco_models.shared.barbell import BarbellSpec
-
     config = ExerciseConfig(
         body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=0.0),
     )
     return SitToStandModelBuilder(config).build()

--- a/tests/integration/test_all_exercises_build.py
+++ b/tests/integration/test_all_exercises_build.py
@@ -33,6 +33,14 @@ ALL_BUILDERS = [
     ("sit_to_stand", build_sit_to_stand_model),
 ]
 
+# Exercises that build a barbell (uses_barbell=True). Gait and sit-to-stand
+# are bodyweight movements and intentionally omit the barbell entirely.
+BARBELL_BUILDERS = [
+    (name, builder)
+    for name, builder in ALL_BUILDERS
+    if name not in {"gait", "sit_to_stand"}
+]
+
 
 class TestAllExercisesBuild:
     @pytest.mark.parametrize(
@@ -98,11 +106,16 @@ class TestAllExercisesBuild:
         "name,builder", ALL_BUILDERS, ids=[n for n, _ in ALL_BUILDERS]
     )
     def test_minimum_body_count(self, name: str, builder: Callable[[], str]) -> None:
-        """Every exercise should have at least 18 bodies (15 body + 3 barbell)."""
+        """Every exercise should have at least 15 body segments.
+
+        Barbell exercises add 3 more bodies (shaft + 2 sleeves); bodyweight
+        exercises (gait, sit-to-stand) only need the 15 body segments.
+        """
         xml_str = builder()
         root = ET.fromstring(xml_str)
         bodies = root.findall(".//body")
-        assert len(bodies) >= 18
+        expected_min = 18 if name not in {"gait", "sit_to_stand"} else 15
+        assert len(bodies) >= expected_min
 
     @pytest.mark.parametrize(
         "name,builder", ALL_BUILDERS, ids=[n for n, _ in ALL_BUILDERS]
@@ -117,15 +130,30 @@ class TestAllExercisesBuild:
                 assert mass > 0, f"{body.get('name')} mass={mass}"  # type: ignore
 
     @pytest.mark.parametrize(
-        "name,builder", ALL_BUILDERS, ids=[n for n, _ in ALL_BUILDERS]
+        "name,builder", BARBELL_BUILDERS, ids=[n for n, _ in BARBELL_BUILDERS]
     )
     def test_barbell_present(self, name: str, builder: Callable[[], str]) -> None:
+        """Barbell exercises must materialise a shaft and both sleeves."""
         xml_str = builder()
         root = ET.fromstring(xml_str)
         body_names = {b.get("name") for b in root.findall(".//body")}  # type: ignore
         assert "barbell_shaft" in body_names
         assert "barbell_left_sleeve" in body_names
         assert "barbell_right_sleeve" in body_names
+
+    @pytest.mark.parametrize(
+        "name",
+        ["gait", "sit_to_stand"],
+    )
+    def test_bodyweight_exercises_omit_barbell(self, name: str) -> None:
+        """Gait and sit-to-stand must not emit any barbell bodies."""
+        builder = dict(ALL_BUILDERS)[name]
+        xml_str = builder()
+        root = ET.fromstring(xml_str)
+        body_names = {b.get("name") for b in root.findall(".//body")}  # type: ignore
+        assert "barbell_shaft" not in body_names
+        assert "barbell_left_sleeve" not in body_names
+        assert "barbell_right_sleeve" not in body_names
 
     @pytest.mark.parametrize(
         "name,builder", ALL_BUILDERS, ids=[n for n, _ in ALL_BUILDERS]

--- a/tests/unit/exercises/gait/test_gait_model.py
+++ b/tests/unit/exercises/gait/test_gait_model.py
@@ -83,3 +83,24 @@ class TestGaitModelBuilder:
         sensor = root.find("sensor")
         assert sensor is not None
         assert len(sensor.findall("jointpos")) > 0
+
+    def test_uses_barbell_flag_is_false(self) -> None:
+        """GaitModelBuilder should opt out of barbell construction."""
+        assert GaitModelBuilder().uses_barbell is False
+
+    def test_build_omits_barbell_bodies(self) -> None:
+        """With uses_barbell=False, no barbell bodies should appear."""
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        body_names = {b.get("name") for b in root.findall(".//body")}
+        assert "barbell_shaft" not in body_names
+        assert "barbell_left_sleeve" not in body_names
+        assert "barbell_right_sleeve" not in body_names
+
+    def test_build_omits_barbell_welds(self) -> None:
+        """With uses_barbell=False, no barbell welds should be emitted."""
+        xml_str = build_gait_model()
+        root = ET.fromstring(xml_str)
+        weld_names = {w.get("name") for w in root.findall(".//weld")}
+        assert "barbell_left_weld" not in weld_names
+        assert "barbell_right_weld" not in weld_names

--- a/tests/unit/exercises/sit_to_stand/test_sit_to_stand_model.py
+++ b/tests/unit/exercises/sit_to_stand/test_sit_to_stand_model.py
@@ -110,3 +110,24 @@ class TestSitToStandModelBuilder:
         sensor = root.find("sensor")
         assert sensor is not None
         assert len(sensor.findall("jointpos")) > 0
+
+    def test_uses_barbell_flag_is_false(self) -> None:
+        """SitToStandModelBuilder should opt out of barbell construction."""
+        assert SitToStandModelBuilder().uses_barbell is False
+
+    def test_build_omits_barbell_bodies(self) -> None:
+        """With uses_barbell=False, no barbell bodies should appear."""
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        body_names = {b.get("name") for b in root.findall(".//body")}
+        assert "barbell_shaft" not in body_names
+        assert "barbell_left_sleeve" not in body_names
+        assert "barbell_right_sleeve" not in body_names
+
+    def test_build_omits_barbell_welds(self) -> None:
+        """With uses_barbell=False, no barbell welds should be emitted."""
+        xml_str = build_sit_to_stand_model()
+        root = ET.fromstring(xml_str)
+        weld_names = {w.get("name") for w in root.findall(".//weld")}
+        assert "barbell_left_weld" not in weld_names
+        assert "barbell_right_weld" not in weld_names

--- a/tests/unit/exercises/test_base.py
+++ b/tests/unit/exercises/test_base.py
@@ -28,6 +28,24 @@ class ForwardingBuilder(ExerciseModelBuilder):
         return None
 
 
+class NoBarbellBuilder(ForwardingBuilder):
+    """Builder that opts out of barbell construction via uses_barbell=False."""
+
+    @property
+    def uses_barbell(self) -> bool:
+        return False
+
+    def attach_barbell(
+        self,
+        equality: ET.Element,
+        body_bodies: dict[str, ET.Element],
+        barbell_bodies: dict[str, ET.Element],
+    ) -> None:
+        raise AssertionError(
+            "attach_barbell must not be called when uses_barbell is False"
+        )
+
+
 class OverriddenAccessorBuilder(ForwardingBuilder):
     def __init__(self) -> None:
         super().__init__(
@@ -66,6 +84,38 @@ class TestExerciseModelBuilderAccessors:
         assert builder.barbell_spec == builder.config.barbell_spec
         assert builder.gravity == builder.config.gravity
         assert builder.grip_offset is None
+
+    def test_uses_barbell_default_true(self) -> None:
+        """Default ExerciseModelBuilder.uses_barbell is True (backward compat)."""
+        builder = ForwardingBuilder(ExerciseConfig())
+        assert builder.uses_barbell is True
+
+    def test_build_with_uses_barbell_true_has_real_mass_shaft(self) -> None:
+        """With uses_barbell=True, the barbell shaft is built with real mass."""
+        config = ExerciseConfig(
+            barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=20.0)
+        )
+        xml_str = ForwardingBuilder(config).build()
+        root = ET.fromstring(xml_str)
+        shaft_inertial = root.find(".//body[@name='barbell_shaft']/inertial")
+        assert shaft_inertial is not None
+        shaft_mass = float(shaft_inertial.get("mass"))  # type: ignore[arg-type]
+        assert shaft_mass > 0.0
+        assert shaft_mass == pytest.approx(config.barbell_spec.shaft_mass)
+
+    def test_build_with_uses_barbell_false_omits_barbell(self) -> None:
+        """With uses_barbell=False, no barbell bodies or welds are emitted."""
+        xml_str = NoBarbellBuilder(ExerciseConfig()).build()
+        root = ET.fromstring(xml_str)
+
+        body_names = {b.get("name") for b in root.findall(".//body")}
+        assert "barbell_shaft" not in body_names
+        assert "barbell_left_sleeve" not in body_names
+        assert "barbell_right_sleeve" not in body_names
+
+        weld_names = {w.get("name") for w in root.findall(".//weld")}
+        assert "barbell_left_weld" not in weld_names
+        assert "barbell_right_weld" not in weld_names
 
     def test_build_uses_accessor_overrides(self) -> None:
         builder = OverriddenAccessorBuilder()


### PR DESCRIPTION
## Summary
- Added `uses_barbell` property to `ExerciseModelBuilder` (default `True`) so `build()` can skip barbell construction and attachment when an exercise has no barbell.
- Overrode `uses_barbell = False` on `GaitModelBuilder` and `SitToStandModelBuilder` and removed the `BarbellSpec.mens_olympic(plate_mass_per_side=0.0)` hack from both convenience builders.
- Updated tests and the `test_all_exercises_build` integration parametrization to reflect that bodyweight exercises no longer emit barbell bodies.

Fixes #118.

## Test plan
- [x] `python3 -m ruff check src tests scripts`
- [x] `python3 -m ruff format --check src tests scripts`
- [x] `python3 -m mypy src --config-file pyproject.toml`
- [x] `python3 -m pytest tests/unit tests/integration -m "not slow and not requires_mujoco"` (580 passed, 14 skipped)
- [x] New `TestExerciseModelBuilderAccessors` cases verify both `uses_barbell=True` (barbell shaft has real mass) and `uses_barbell=False` (bodies/welds omitted).
- [x] New gait and sit-to-stand regression tests assert no barbell bodies or welds appear in their MJCF output.

Generated with Claude Code.