### PR TITLE
[codex] Reject non-finite MuJoCo scalar contract values

### DIFF
--- a/src/mujoco_models/shared/contracts/preconditions.py
+++ b/src/mujoco_models/shared/contracts/preconditions.py
@@ -13,12 +13,14 @@ from numpy.typing import ArrayLike
 
 def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
+    require_finite(value, name)
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
+    require_finite(value, name)
     if value < 0:
         raise ValueError(f"{name} must be non-negative, got {value}")
 
@@ -42,6 +44,7 @@ def require_finite(arr: ArrayLike, name: str) -> None:
 
 def require_in_range(value: float, low: float, high: float, name: str) -> None:
     """Require *low* <= *value* <= *high*."""
+    require_finite([value, low, high], name)
     if not (low <= value <= high):
         raise ValueError(f"{name} must be in [{low}, {high}], got {value}")
 

--- a/tests/unit/shared/test_preconditions.py
+++ b/tests/unit/shared/test_preconditions.py
@@ -25,6 +25,11 @@ class TestRequirePositive:
         with pytest.raises(ValueError, match="must be positive"):
             require_positive(-1.0, "x")
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_positive(value, "x")
+
     def test_includes_name_in_message(self) -> None:
         with pytest.raises(ValueError, match="mass"):
             require_positive(-5.0, "mass")
@@ -40,6 +45,11 @@ class TestRequireNonNegative:
     def test_rejects_negative(self) -> None:
         with pytest.raises(ValueError, match="must be non-negative"):
             require_non_negative(-0.001, "x")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_non_negative(value, "x")
 
 
 class TestRequireUnitVector:
@@ -96,6 +106,11 @@ class TestRequireInRange:
     def test_rejects_above(self) -> None:
         with pytest.raises(ValueError, match="must be in"):
             require_in_range(11.0, 0.0, 10.0, "x")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_value(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_in_range(value, 0.0, 10.0, "x")
 
 
 class TestRequireShape:


### PR DESCRIPTION
## Summary
- Make shared scalar contract guards reject NaN and infinities directly.
- Cover `require_positive`, `require_non_negative`, and `require_in_range` non-finite cases.

Closes #136

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_preconditions.py -q -o addopts=''`
