### PR TITLE
refactor(#129): A-N Refresh P1 items batch 1

### DIFF
--- a/examples/generate_all_models.py
+++ b/examples/generate_all_models.py
@@ -17,12 +17,8 @@ from mujoco_models.shared.barbell import BarbellSpec
 from mujoco_models.shared.body import BodyModelSpec
 
 
-def main() -> None:
-    """Generate MJCF XML files for all registered exercise models.
-
-    Parses command-line arguments and writes one XML file per exercise
-    to the configured output directory.
-    """
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for ``generate_all_models``."""
     parser = argparse.ArgumentParser(description="Generate all exercise models.")
     parser.add_argument(
         "--output-dir",
@@ -42,30 +38,69 @@ def main() -> None:
         default=1.75,
         help="Body height in meters (default: 1.75).",
     )
-    args = parser.parse_args()
+    return parser
 
-    os.makedirs(args.output_dir, exist_ok=True)
 
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=args.body_mass, height=args.height),
+def _build_config(body_mass: float, height: float) -> ExerciseConfig:
+    """Build an :class:`ExerciseConfig` with validated anthropometry.
+
+    Preconditions:
+        ``body_mass > 0`` and ``height > 0``.  :class:`BodyModelSpec`
+        enforces the contract and raises :class:`ValueError` otherwise.
+    """
+    return ExerciseConfig(
+        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
         barbell_spec=BarbellSpec.mens_olympic(),
     )
 
-    # Deduplicate builders (some exercises share a builder, e.g. squat/back_squat)
+
+def _write_model(
+    name: str, builder_cls: type, config: ExerciseConfig, output_dir: str
+) -> str:
+    """Build one exercise model and write it to ``<output_dir>/<name>.xml``.
+
+    Returns the output path so the caller can report progress.
+    """
+    xml_str = builder_cls(config).build()
+    out_path = os.path.join(output_dir, f"{name}.xml")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write(xml_str)
+    return out_path
+
+
+def _iter_unique_builders() -> list[tuple[str, type]]:
+    """Yield ``(name, builder_cls)`` pairs with duplicate classes removed.
+
+    Some exercises share a builder (e.g. squat/back_squat).  We emit each
+    unique class once using the alphabetically-first alias.
+    """
     seen: set[str] = set()
+    unique: list[tuple[str, type]] = []
     for name, builder_cls in sorted(EXERCISE_REGISTRY.items()):
         cls_name = builder_cls.__name__
         if cls_name in seen:
             continue
         seen.add(cls_name)
+        unique.append((name, builder_cls))
+    return unique
 
-        xml_str = builder_cls(config).build()
-        out_path = os.path.join(args.output_dir, f"{name}.xml")
-        with open(out_path, "w") as fh:
-            fh.write(xml_str)
+
+def main() -> None:
+    """Generate MJCF XML files for all registered exercise models.
+
+    Parses command-line arguments and writes one XML file per exercise
+    to the configured output directory.
+    """
+    args = _build_parser().parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    config = _build_config(args.body_mass, args.height)
+    unique = _iter_unique_builders()
+    for name, builder_cls in unique:
+        out_path = _write_model(name, builder_cls, config, args.output_dir)
         print(f"Wrote {out_path}")
 
-    print(f"Generated {len(seen)} models in {args.output_dir}/")
+    print(f"Generated {len(unique)} models in {args.output_dir}/")
 
 
 if __name__ == "__main__":

--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -14,17 +14,17 @@ from mujoco_models.shared.body import BodyModelSpec
 logger = logging.getLogger(__name__)
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    """Create the argument parser for the CLI."""
-    parser = argparse.ArgumentParser(
-        prog="python -m mujoco_models",
-        description="Generate MuJoCo MJCF models for barbell exercises.",
-    )
+def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the positional ``exercise`` argument."""
     parser.add_argument(
         "exercise",
         choices=sorted(set(EXERCISE_REGISTRY.keys())),
         help="Exercise to generate a model for.",
     )
+
+
+def _add_anthropometry_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add ``--body-mass``, ``--height`` and ``--plate-mass`` options."""
     parser.add_argument(
         "--body-mass",
         type=float,
@@ -43,6 +43,10 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0.0,
         help="Plate mass per side in kg (default: 0.0).",
     )
+
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add output-file and verbosity options."""
     parser.add_argument(
         "-o",
         "--output",
@@ -56,6 +60,17 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable verbose logging.",
     )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the CLI."""
+    parser = argparse.ArgumentParser(
+        prog="python -m mujoco_models",
+        description="Generate MuJoCo MJCF models for barbell exercises.",
+    )
+    _add_exercise_argument(parser)
+    _add_anthropometry_arguments(parser)
+    _add_output_arguments(parser)
     return parser
 
 

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -318,6 +318,33 @@ class ExerciseModelBuilder(ABC):
             key.set("name", f"{self.exercise_name}_start")
             key.set("qpos", " ".join(qpos_values))
 
+    def _build_bodies_and_barbell(
+        self, worldbody: ET.Element, equality: ET.Element
+    ) -> tuple[dict[str, ET.Element], dict[str, ET.Element]]:
+        """Build body segments and (optionally) barbell inside the worldbody.
+
+        Returns ``(body_bodies, barbell_bodies)`` where ``barbell_bodies`` is
+        empty when :attr:`uses_barbell` is ``False``.
+        """
+        body_bodies = create_full_body(worldbody, self.body_spec)
+        barbell_bodies: dict[str, ET.Element] = {}
+        if self.uses_barbell:
+            barbell_bodies = create_barbell_bodies(
+                worldbody, equality, self.barbell_spec
+            )
+            self.attach_barbell(equality, body_bodies, barbell_bodies)
+        return body_bodies, barbell_bodies
+
+    def _finalize_model(self, root: ET.Element) -> str:
+        """Serialize *root* and verify MJCF postconditions.
+
+        Postcondition: returned string is well-formed MJCF XML whose root
+        element is ``<mujoco>``.
+        """
+        xml_str = serialize_model(root)
+        ensure_mjcf_root(xml_str)
+        return xml_str
+
     def build(self) -> str:
         """Build the complete MuJoCo MJCF model XML and return as string.
 
@@ -326,44 +353,20 @@ class ExerciseModelBuilder(ABC):
         """
         logger.info("Building %s model", self.exercise_name)
 
-        # Step 1: root element with options / compiler / defaults
         root = self._create_root_element()
-
-        # Step 2: worldbody with ground plane
         worldbody = self._create_worldbody(root)
-
-        # Step 3: equality constraints section
         equality = ET.SubElement(root, "equality")
 
-        # Step 4: body and (optionally) barbell
-        body_bodies = create_full_body(worldbody, self.body_spec)
-        barbell_bodies: dict[str, ET.Element] = {}
-        if self.uses_barbell:
-            barbell_bodies = create_barbell_bodies(
-                worldbody, equality, self.barbell_spec
-            )
-
-        # Step 5: exercise-specific attachment and hook
-        if self.uses_barbell:
-            self.attach_barbell(equality, body_bodies, barbell_bodies)
+        self._build_bodies_and_barbell(worldbody, equality)
         self._post_worldbody_hook(worldbody, equality)
 
-        # Step 6: contact exclusions
         contact = ET.SubElement(root, "contact")
         _add_contact_exclusions(contact)
 
-        # Step 7: initial pose
         self.set_initial_pose(worldbody)
-
-        # Step 8: actuators and sensors
         self._add_actuators_and_sensors(root, worldbody)
-
-        # Step 9: keyframe
         self._build_keyframe(root, worldbody)
 
-        # Serialize and validate
-        xml_str = serialize_model(root)
-        ensure_mjcf_root(xml_str)
-
+        xml_str = self._finalize_model(root)
         logger.debug("Successfully built %s model", self.exercise_name)
         return xml_str

--- a/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -74,14 +74,30 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
         """
 
     def _post_worldbody_hook(self, worldbody: ET.Element, equality: ET.Element) -> None:
-        """Add a chair body welded to the ground plane."""
-        chair = ET.SubElement(
+        """Add a chair body welded to the ground plane.
+
+        Decomposed into helpers per the single-responsibility rule:
+        one function per geometric piece plus one for the weld.
+        """
+        chair = self._create_chair_body(worldbody)
+        self._add_chair_seat_geom(chair)
+        self._add_chair_back_geom(chair)
+        self._weld_chair_to_world(equality)
+        logger.debug("Added chair at seat height %.3f m", _CHAIR_SEAT_HEIGHT)
+
+    @staticmethod
+    def _create_chair_body(worldbody: ET.Element) -> ET.Element:
+        """Create the parent ``<body name="chair">`` element."""
+        return ET.SubElement(
             worldbody,
             "body",
             name="chair",
             pos=f"0 0 {_CHAIR_SEAT_HEIGHT / 2:.4f}",
         )
-        # Chair seat
+
+    @staticmethod
+    def _add_chair_seat_geom(chair: ET.Element) -> None:
+        """Add the horizontal seat box geom."""
         ET.SubElement(
             chair,
             "geom",
@@ -93,7 +109,10 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
             contype="1",
             conaffinity="1",
         )
-        # Chair back
+
+    @staticmethod
+    def _add_chair_back_geom(chair: ET.Element) -> None:
+        """Add the vertical chair-back box geom."""
         ET.SubElement(
             chair,
             "geom",
@@ -107,7 +126,10 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
             ),
             rgba="0.6 0.4 0.2 1",
         )
-        # Weld chair to world (immovable)
+
+    @staticmethod
+    def _weld_chair_to_world(equality: ET.Element) -> None:
+        """Weld the chair body to the world so it is immovable."""
         ET.SubElement(
             equality,
             "weld",
@@ -115,7 +137,6 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
             body1="chair",
             relpose="0 0 0 1 0 0 0",
         )
-        logger.debug("Added chair at seat height %.3f m", _CHAIR_SEAT_HEIGHT)
 
     def set_initial_pose(self, worldbody: ET.Element) -> None:
         """Set seated position: ~90 deg hip and knee flexion.

--- a/src/mujoco_models/shared/body/body_helpers.py
+++ b/src/mujoco_models/shared/body/body_helpers.py
@@ -17,6 +17,46 @@ logger = logging.getLogger(__name__)
 _ExtraJoints = list[tuple[str, tuple[float, float, float], float, float]]
 
 
+# Foot contact-geometry constants.  Centralizing here removes magic numbers
+# from the sub-element calls and keeps the geometry documented in one place.
+# Half-sizes correspond to a 0.26 m x 0.10 m x 0.02 m contact box.
+_FOOT_CONTACT_SIZE = "0.13 0.05 0.01"
+_FOOT_CONTACT_POS = "0.04 0 -0.02"  # slightly forward and at bottom of foot
+_FOOT_CONTACT_FRICTION = "1.0 0.005 0.0001"  # tangent, torsion, rolling
+_FOOT_CONTACT_RGBA = "0.8 0.6 0.4 0.3"  # semi-transparent for visualization
+
+
+def _demote_visual_geom_group(foot_body: ET.Element) -> None:
+    """Move the existing (visual) foot geom into group 0 if present.
+
+    Separating visual and contact geoms by ``group`` lets MuJoCo render
+    without the contact box drawn on top of the visual capsule.
+    """
+    visual_geom = foot_body.find("geom")
+    if visual_geom is not None:
+        visual_geom.set("group", "0")
+
+
+def _add_single_foot_contact_geom(foot_body: ET.Element, side: str) -> None:
+    """Attach the standard sole-contact box geom to a single foot body.
+
+    Args:
+        foot_body: The ``<body name="foot_{side}">`` element.
+        side: One of ``"l"`` or ``"r"``.
+    """
+    contact_geom = ET.SubElement(foot_body, "geom")
+    contact_geom.set("name", f"foot_{side}_contact")
+    contact_geom.set("type", "box")
+    contact_geom.set("size", _FOOT_CONTACT_SIZE)
+    contact_geom.set("pos", _FOOT_CONTACT_POS)
+    contact_geom.set("contype", "1")
+    contact_geom.set("conaffinity", "1")
+    contact_geom.set("condim", "3")
+    contact_geom.set("friction", _FOOT_CONTACT_FRICTION)
+    contact_geom.set("group", "1")
+    contact_geom.set("rgba", _FOOT_CONTACT_RGBA)
+
+
 def add_foot_contact_geoms(bodies: dict[str, ET.Element]) -> None:
     """Add box collision geometry to foot segments for ground contact.
 
@@ -27,34 +67,16 @@ def add_foot_contact_geoms(bodies: dict[str, ET.Element]) -> None:
     Contact properties: contype=1, conaffinity=1, condim=3,
     friction="1.0 0.005 0.0001" (tangent, torsion, rolling).
     Group=1 separates contact geoms from visual geoms (group=0).
+
+    Missing sides (e.g. unilateral rigs) are silently skipped; callers
+    that require a specific side should check ``bodies`` themselves.
     """
     for side in ("l", "r"):
         foot_body = bodies.get(f"foot_{side}")
         if foot_body is None:
             continue
-
-        # Get the visual geom to determine the foot's vertical extent
-        visual_geom = foot_body.find("geom")
-        if visual_geom is not None:
-            visual_geom.set("group", "0")
-
-        contact_geom = ET.SubElement(foot_body, "geom")
-        contact_geom.set("name", f"foot_{side}_contact")
-        contact_geom.set("type", "box")
-        contact_geom.set(
-            "size", "0.13 0.05 0.01"
-        )  # half-sizes: 0.26/2 x 0.10/2 x 0.02/2
-        contact_geom.set(
-            "pos", "0.04 0 -0.02"
-        )  # slightly forward and at bottom of foot
-        contact_geom.set("contype", "1")
-        contact_geom.set("conaffinity", "1")
-        contact_geom.set("condim", "3")
-        contact_geom.set("friction", "1.0 0.005 0.0001")
-        contact_geom.set("group", "1")
-        contact_geom.set(
-            "rgba", "0.8 0.6 0.4 0.3"
-        )  # semi-transparent for visualization
+        _demote_visual_geom_group(foot_body)
+        _add_single_foot_contact_geom(foot_body, side)
 
     logger.debug("Added contact sole geometry to foot segments")
 

--- a/tests/unit/exercises/sit_to_stand/test_chair_helpers.py
+++ b/tests/unit/exercises/sit_to_stand/test_chair_helpers.py
@@ -1,0 +1,76 @@
+"""Unit tests for the chair-building helpers on SitToStandModelBuilder.
+
+Covers the helpers extracted during the A-N Refresh 2026-04-14 decomposition
+of ``_post_worldbody_hook`` (issue #129).  TDD: these assertions pin down
+the expected XML shape of each piece individually, so future refactors
+can edit a single helper with confidence.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from mujoco_models.exercises.sit_to_stand.sit_to_stand_model import (
+    SitToStandModelBuilder,
+)
+
+
+def test_create_chair_body_attaches_named_body() -> None:
+    """``_create_chair_body`` returns a body named ``chair`` parented to worldbody."""
+    worldbody = ET.Element("worldbody")
+    chair = SitToStandModelBuilder._create_chair_body(worldbody)
+    assert chair.tag == "body"
+    assert chair.get("name") == "chair"
+    assert chair in list(worldbody)
+
+
+def test_add_chair_seat_geom_is_a_box_geom_with_contact_flags() -> None:
+    """Seat geom is a contact-enabled box named ``chair_seat``."""
+    chair = ET.Element("body")
+    SitToStandModelBuilder._add_chair_seat_geom(chair)
+    geoms = chair.findall("geom")
+    assert len(geoms) == 1
+    seat = geoms[0]
+    assert seat.get("name") == "chair_seat"
+    assert seat.get("type") == "box"
+    assert seat.get("contype") == "1"
+    assert seat.get("conaffinity") == "1"
+
+
+def test_add_chair_back_geom_positions_behind_seat() -> None:
+    """Chair back has negative Y position (behind the pelvis origin)."""
+    chair = ET.Element("body")
+    SitToStandModelBuilder._add_chair_back_geom(chair)
+    back = chair.find("geom")
+    assert back is not None
+    assert back.get("name") == "chair_back"
+    pos = back.get("pos", "")
+    # pos is "0 <negY> <posZ>" -- second token should start with minus sign
+    y_token = pos.split()[1]
+    assert y_token.startswith("-"), f"expected negative Y in back pos, got {pos!r}"
+
+
+def test_weld_chair_to_world_creates_fixed_weld() -> None:
+    """``_weld_chair_to_world`` emits an identity-weld for the chair body."""
+    equality = ET.Element("equality")
+    SitToStandModelBuilder._weld_chair_to_world(equality)
+    welds = equality.findall("weld")
+    assert len(welds) == 1
+    weld = welds[0]
+    assert weld.get("name") == "chair_to_world"
+    assert weld.get("body1") == "chair"
+    assert weld.get("relpose") == "0 0 0 1 0 0 0"
+
+
+def test_post_worldbody_hook_assembles_full_chair() -> None:
+    """The public hook still produces: chair body + 2 geoms + 1 weld."""
+    builder = SitToStandModelBuilder()
+    worldbody = ET.Element("worldbody")
+    equality = ET.Element("equality")
+    builder._post_worldbody_hook(worldbody, equality)
+
+    chairs = worldbody.findall("body[@name='chair']")
+    assert len(chairs) == 1
+    geoms = chairs[0].findall("geom")
+    assert {g.get("name") for g in geoms} == {"chair_seat", "chair_back"}
+    assert len(equality.findall("weld[@name='chair_to_world']")) == 1

--- a/tests/unit/exercises/test_base.py
+++ b/tests/unit/exercises/test_base.py
@@ -145,3 +145,52 @@ class TestExerciseModelBuilderAccessors:
             weld.get("relpose")
             == "0.010000 0.020000 0.030000 1.000000 0.000000 0.000000 0.000000"
         )
+
+
+class TestBuildDecomposition:
+    """Tests for helpers extracted from ``build()`` in A-N Refresh 2026-04-14."""
+
+    def test_build_bodies_and_barbell_with_barbell(self) -> None:
+        """Both body and barbell bodies are populated when barbell is enabled."""
+        builder = ForwardingBuilder(ExerciseConfig())
+        worldbody = ET.Element("worldbody")
+        equality = ET.Element("equality")
+
+        body_bodies, barbell_bodies = builder._build_bodies_and_barbell(
+            worldbody, equality
+        )
+        assert "pelvis" in body_bodies
+        assert "barbell_shaft" in barbell_bodies
+        # attach_barbell produced weld constraints
+        weld_names = {w.get("name") for w in equality.findall("weld")}
+        assert "barbell_to_hand_l" in weld_names
+        assert "barbell_to_hand_r" in weld_names
+
+    def test_build_bodies_and_barbell_without_barbell(self) -> None:
+        """When ``uses_barbell`` is False, barbell_bodies is empty and no weld is added."""
+        builder = NoBarbellBuilder(ExerciseConfig())
+        worldbody = ET.Element("worldbody")
+        equality = ET.Element("equality")
+
+        body_bodies, barbell_bodies = builder._build_bodies_and_barbell(
+            worldbody, equality
+        )
+        assert body_bodies  # body still built
+        assert barbell_bodies == {}
+        assert equality.findall("weld") == []
+
+    def test_finalize_model_validates_mjcf_root(self) -> None:
+        """``_finalize_model`` returns serialized XML whose root is ``<mujoco>``."""
+        builder = ForwardingBuilder(ExerciseConfig())
+        root = ET.Element("mujoco", model="dummy")
+        ET.SubElement(root, "worldbody")
+        xml_str = builder._finalize_model(root)
+        assert "<mujoco" in xml_str
+        assert ET.fromstring(xml_str).tag == "mujoco"
+
+    def test_finalize_model_rejects_non_mujoco_root(self) -> None:
+        """A non-``<mujoco>`` root violates the MJCF postcondition."""
+        builder = ForwardingBuilder(ExerciseConfig())
+        bad_root = ET.Element("notmujoco")
+        with pytest.raises(ValueError, match="MJCF root"):
+            builder._finalize_model(bad_root)

--- a/tests/unit/shared/test_body_helpers_decomposition.py
+++ b/tests/unit/shared/test_body_helpers_decomposition.py
@@ -1,0 +1,75 @@
+"""Unit tests for the foot-contact helpers in body_helpers.py.
+
+Covers the decomposition of ``add_foot_contact_geoms`` (issue #129,
+A-N Refresh 2026-04-14) into:
+
+* ``_demote_visual_geom_group`` -- moves any existing geom into group "0".
+* ``_add_single_foot_contact_geom`` -- appends the contact box for one side.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from mujoco_models.shared.body import body_helpers
+from mujoco_models.shared.body.body_helpers import (
+    _add_single_foot_contact_geom,
+    _demote_visual_geom_group,
+    add_foot_contact_geoms,
+)
+
+
+def test_demote_visual_geom_group_sets_group_zero() -> None:
+    """An existing geom should be marked as group 0 (visual)."""
+    foot = ET.Element("body", name="foot_l")
+    existing = ET.SubElement(foot, "geom", type="capsule")
+    _demote_visual_geom_group(foot)
+    assert existing.get("group") == "0"
+
+
+def test_demote_visual_geom_group_is_noop_without_geom() -> None:
+    """Missing visual geom is not an error."""
+    foot = ET.Element("body", name="foot_r")
+    _demote_visual_geom_group(foot)  # must not raise
+
+
+def test_add_single_foot_contact_geom_writes_all_attributes() -> None:
+    """Contact geom carries contact flags, friction, and the group=1 marker."""
+    foot = ET.Element("body", name="foot_l")
+    _add_single_foot_contact_geom(foot, "l")
+    geoms = foot.findall("geom")
+    assert len(geoms) == 1
+    g = geoms[0]
+    assert g.get("name") == "foot_l_contact"
+    assert g.get("type") == "box"
+    assert g.get("size") == body_helpers._FOOT_CONTACT_SIZE
+    assert g.get("pos") == body_helpers._FOOT_CONTACT_POS
+    assert g.get("friction") == body_helpers._FOOT_CONTACT_FRICTION
+    assert g.get("rgba") == body_helpers._FOOT_CONTACT_RGBA
+    assert g.get("contype") == "1"
+    assert g.get("conaffinity") == "1"
+    assert g.get("condim") == "3"
+    assert g.get("group") == "1"
+
+
+def test_add_foot_contact_geoms_handles_both_feet() -> None:
+    """Both ``foot_l`` and ``foot_r`` gain a contact box and visual demotion."""
+    foot_l = ET.Element("body", name="foot_l")
+    ET.SubElement(foot_l, "geom", type="capsule", name="foot_l_visual")
+    foot_r = ET.Element("body", name="foot_r")
+    ET.SubElement(foot_r, "geom", type="capsule", name="foot_r_visual")
+
+    add_foot_contact_geoms({"foot_l": foot_l, "foot_r": foot_r})
+
+    for side, foot in (("l", foot_l), ("r", foot_r)):
+        names = {g.get("name") for g in foot.findall("geom")}
+        assert f"foot_{side}_contact" in names
+        assert f"foot_{side}_visual" in names
+        visual = foot.find("geom[@name='foot_" + side + "_visual']")
+        assert visual is not None
+        assert visual.get("group") == "0"
+
+
+def test_add_foot_contact_geoms_skips_missing_sides() -> None:
+    """A dict without the expected keys is tolerated silently (no raise)."""
+    add_foot_contact_geoms({})  # must not raise

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,0 +1,63 @@
+"""Unit tests for the argument-parser decomposition in ``__main__``.
+
+Covers the helpers introduced during A-N Refresh 2026-04-14 (issue #129)
+that split ``_build_parser`` into three focused functions.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from mujoco_models import __main__ as cli
+from mujoco_models.exercises import EXERCISE_REGISTRY
+
+
+def test_add_exercise_argument_restricts_to_known_exercises() -> None:
+    """Invalid exercise names are rejected by argparse."""
+    p = argparse.ArgumentParser()
+    cli._add_exercise_argument(p)
+    # Valid exercise succeeds
+    known = sorted(EXERCISE_REGISTRY.keys())[0]
+    ns = p.parse_args([known])
+    assert ns.exercise == known
+    # Unknown exercise raises SystemExit (argparse error)
+    with pytest.raises(SystemExit):
+        p.parse_args(["not_a_real_exercise"])
+
+
+def test_add_anthropometry_arguments_supplies_defaults() -> None:
+    """Anthropometry args default to the documented 80 kg / 1.75 m / 0 kg."""
+    p = argparse.ArgumentParser()
+    cli._add_anthropometry_arguments(p)
+    ns = p.parse_args([])
+    assert ns.body_mass == pytest.approx(80.0)
+    assert ns.height == pytest.approx(1.75)
+    assert ns.plate_mass == pytest.approx(0.0)
+
+
+def test_add_output_arguments_toggles_verbose_flag() -> None:
+    """``-v`` flips ``verbose`` to True; output path optional."""
+    p = argparse.ArgumentParser()
+    cli._add_output_arguments(p)
+    ns = p.parse_args(["-v"])
+    assert ns.verbose is True
+    assert ns.output is None
+    ns2 = p.parse_args(["-o", "/tmp/out.xml"])
+    assert ns2.verbose is False
+    assert ns2.output == "/tmp/out.xml"
+
+
+def test_build_parser_composes_all_argument_groups() -> None:
+    """End-to-end parse exercises all three helper groups."""
+    p = cli._build_parser()
+    known = sorted(EXERCISE_REGISTRY.keys())[0]
+    ns = p.parse_args(
+        [known, "--body-mass", "70", "--height", "1.8", "--plate-mass", "20", "-v"]
+    )
+    assert ns.exercise == known
+    assert ns.body_mass == pytest.approx(70.0)
+    assert ns.height == pytest.approx(1.8)
+    assert ns.plate_mass == pytest.approx(20.0)
+    assert ns.verbose is True

--- a/tests/unit/test_generate_all_models.py
+++ b/tests/unit/test_generate_all_models.py
@@ -1,0 +1,76 @@
+"""Unit tests for the ``examples/generate_all_models.py`` helpers.
+
+Loaded via ``importlib`` because ``examples/`` is not a package in the
+source tree.  Covers the decomposition done during A-N Refresh
+2026-04-14 (issue #129).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+from mujoco_models.exercises.base import ExerciseConfig
+
+
+def _load_module() -> object:
+    """Load ``examples/generate_all_models.py`` as a module object."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "examples" / "generate_all_models.py"
+    spec = importlib.util.spec_from_file_location("generate_all_models", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_build_parser_defaults() -> None:
+    """Default parse yields ``output`` dir and 80 kg / 1.75 m anthropometry."""
+    mod = _load_module()
+    parser = mod._build_parser()  # type: ignore[attr-defined]
+    ns = parser.parse_args([])
+    assert ns.output_dir == "output"
+    assert ns.body_mass == pytest.approx(80.0)
+    assert ns.height == pytest.approx(1.75)
+
+
+def test_build_config_produces_exercise_config() -> None:
+    """``_build_config`` wraps user anthropometry in an ExerciseConfig."""
+    mod = _load_module()
+    cfg = mod._build_config(72.0, 1.70)  # type: ignore[attr-defined]
+    assert isinstance(cfg, ExerciseConfig)
+    assert cfg.body_spec.total_mass == pytest.approx(72.0)
+    assert cfg.body_spec.height == pytest.approx(1.70)
+
+
+def test_build_config_enforces_positive_mass() -> None:
+    """Preconditions are inherited from BodyModelSpec: zero mass is rejected."""
+    mod = _load_module()
+    with pytest.raises(ValueError):
+        mod._build_config(0.0, 1.75)  # type: ignore[attr-defined]
+
+
+def test_iter_unique_builders_deduplicates_by_class() -> None:
+    """Each unique builder class appears exactly once."""
+    mod = _load_module()
+    unique = mod._iter_unique_builders()  # type: ignore[attr-defined]
+    classes = [cls.__name__ for _, cls in unique]
+    assert len(classes) == len(set(classes))
+
+
+def test_write_model_writes_xml_file(tmp_path) -> None:
+    """``_write_model`` produces an MJCF XML file at the expected path."""
+    mod = _load_module()
+    unique = mod._iter_unique_builders()  # type: ignore[attr-defined]
+    name, builder_cls = unique[0]
+    cfg = ExerciseConfig()
+    out_path = mod._write_model(  # type: ignore[attr-defined]
+        name, builder_cls, cfg, str(tmp_path)
+    )
+    assert os.path.exists(out_path)
+    with open(out_path, encoding="utf-8") as fh:
+        head = fh.read(200)
+    assert "<mujoco" in head


### PR DESCRIPTION
## Summary

Addresses 4 of the 5 oversized-function P1 items from the 2026-04-11 A-N
Refresh (#129). Each of the selected functions now falls under 30 LOC,
has a single responsibility, and is covered by new unit tests (TDD).

## Items addressed

- [x] `examples/generate_all_models.py::main` (51 LOC) -> extract
      `_build_parser`, `_build_config`, `_write_model`,
      `_iter_unique_builders`.
- [x] `src/mujoco_models/__main__.py::_build_parser` (45 LOC) -> split
      into `_add_exercise_argument`, `_add_anthropometry_arguments`,
      `_add_output_arguments`.
- [x] `src/mujoco_models/exercises/base.py::build` (44 LOC) -> extract
      `_build_bodies_and_barbell` and `_finalize_model`.
- [x] `src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py::`
      `_post_worldbody_hook` (44 LOC) -> split into
      `_create_chair_body`, `_add_chair_seat_geom`,
      `_add_chair_back_geom`, `_weld_chair_to_world`.
- [x] `src/mujoco_models/shared/body/body_helpers.py::`
      `add_foot_contact_geoms` (42 LOC) -> extract
      `_demote_visual_geom_group`, `_add_single_foot_contact_geom`;
      lift magic attribute values to module constants.

## Items deferred

- [ ] `src/mujoco_models/shared/body/body_model.py` (448 LOC monolith)
      -- owned by a separate in-flight PR for #117. Left untouched per
      multi-agent coordination notes.

## Design notes

- DRY: common contact-geom constants (`_FOOT_CONTACT_SIZE`,
  `_FOOT_CONTACT_POS`, etc.) now live in one place.
- DbC: `_build_config` documents the underlying `BodyModelSpec`
  preconditions; `_finalize_model` makes the postcondition (MJCF root
  tag) explicit via `ensure_mjcf_root` and a dedicated unit test.
- LOD: no new chain-call violations introduced; new helpers take the
  containers they need as explicit parameters.

## Test plan

- [x] `python3 -m pytest -n auto --timeout=60` -- 641 pass, 14 skipped
      (MuJoCo + Hypothesis not installed locally; CI runs both).
- [x] `ruff check src tests examples` clean.
- [x] `ruff format --check` clean.
- [ ] CI: ruff + mypy + coverage across Python 3.10/3.11/3.12.

Refs #129.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>