### PR TITLE
refactor(#122): decompose oversized Python functions (A-N 2026-04-10)

### DIFF
--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -74,45 +74,76 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI main function. Returns 0 on success, 1 on error."""
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+def _configure_logging(verbose: bool) -> None:
+    """Initialise the root logger for the CLI run.
 
+    Precondition: called exactly once per CLI invocation.
+    """
     logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.WARNING,
+        level=logging.DEBUG if verbose else logging.WARNING,
         format="%(name)s %(levelname)s: %(message)s",
     )
 
+
+def _build_config_from_args(args: argparse.Namespace) -> ExerciseConfig | None:
+    """Build an :class:`ExerciseConfig` from parsed CLI args.
+
+    Returns ``None`` and logs an error on invalid anthropometry, so the
+    caller can exit with a non-zero status without catching exceptions.
+    """
     try:
-        config = ExerciseConfig(
+        return ExerciseConfig(
             body_spec=BodyModelSpec(total_mass=args.body_mass, height=args.height),
             barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=args.plate_mass),
         )
     except ValueError as exc:
         logger.error("Invalid configuration: %s", exc)
-        return 1
+        return None
 
-    builder_cls = EXERCISE_REGISTRY[args.exercise]
 
+def _build_model_xml(exercise: str, config: ExerciseConfig) -> str | None:
+    """Instantiate the registered builder for *exercise* and call ``build()``.
+
+    Returns the MJCF XML string, or ``None`` when the builder raises a
+    known error (``ValueError`` or ``RuntimeError``).
+    """
+    builder_cls = EXERCISE_REGISTRY[exercise]
     try:
-        xml_str = builder_cls(config).build()
+        return builder_cls(config).build()
     except (ValueError, RuntimeError) as exc:
-        logger.error("Model build failed for '%s': %s", args.exercise, exc)
+        logger.error("Model build failed for '%s': %s", exercise, exc)
+        return None
+
+
+def _emit_xml(xml_str: str, output: str | None) -> int:
+    """Write *xml_str* to *output* (or stdout) and return an exit code."""
+    if output is None:
+        sys.stdout.write(xml_str)
+        return 0
+    try:
+        with open(output, "w", encoding="utf-8") as fh:
+            fh.write(xml_str)
+    except OSError as exc:
+        logger.error("Failed to write output file '%s': %s", output, exc)
+        return 1
+    logger.info("Wrote %s", output)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI main function. Returns 0 on success, 1 on error."""
+    args = _build_parser().parse_args(argv)
+    _configure_logging(args.verbose)
+
+    config = _build_config_from_args(args)
+    if config is None:
         return 1
 
-    if args.output:
-        try:
-            with open(args.output, "w", encoding="utf-8") as fh:
-                fh.write(xml_str)
-        except OSError as exc:
-            logger.error("Failed to write output file '%s': %s", args.output, exc)
-            return 1
-        logger.info("Wrote %s", args.output)
-    else:
-        sys.stdout.write(xml_str)
+    xml_str = _build_model_xml(args.exercise, config)
+    if xml_str is None:
+        return 1
 
-    return 0
+    return _emit_xml(xml_str, args.output)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,17 +1,22 @@
 """Unit tests for the argument-parser decomposition in ``__main__``.
 
 Covers the helpers introduced during A-N Refresh 2026-04-14 (issue #129)
-that split ``_build_parser`` into three focused functions.
+that split ``_build_parser`` into three focused functions, plus the
+``main()`` decomposition helpers added in issue #122 (A-N 2026-04-10).
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 from mujoco_models import __main__ as cli
 from mujoco_models.exercises import EXERCISE_REGISTRY
+from mujoco_models.exercises.base import ExerciseConfig
 
 
 def test_add_exercise_argument_restricts_to_known_exercises() -> None:
@@ -61,3 +66,125 @@ def test_build_parser_composes_all_argument_groups() -> None:
     assert ns.height == pytest.approx(1.8)
     assert ns.plate_mass == pytest.approx(20.0)
     assert ns.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# Helpers extracted from ``main`` for issue #122 (A-N 2026-04-10 refresh)
+# ---------------------------------------------------------------------------
+
+
+def _default_args(**overrides: Any) -> argparse.Namespace:
+    """Build a parsed ``Namespace`` matching CLI defaults, with overrides."""
+    defaults = {
+        "exercise": sorted(EXERCISE_REGISTRY.keys())[0],
+        "body_mass": 80.0,
+        "height": 1.75,
+        "plate_mass": 0.0,
+        "output": None,
+        "verbose": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_configure_logging_forwards_verbose_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verbose flag forwards ``DEBUG`` to ``logging.basicConfig``."""
+    captured: dict[str, Any] = {}
+
+    def _fake_basic_config(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", _fake_basic_config)
+    cli._configure_logging(verbose=True)
+    assert captured.get("level") == logging.DEBUG
+
+
+def test_configure_logging_defaults_to_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-verbose invocation forwards ``WARNING`` to ``logging.basicConfig``."""
+    captured: dict[str, Any] = {}
+
+    def _fake_basic_config(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", _fake_basic_config)
+    cli._configure_logging(verbose=False)
+    assert captured.get("level") == logging.WARNING
+    assert "format" in captured
+
+
+def test_build_config_from_args_returns_valid_config() -> None:
+    """Valid anthropometry yields an ``ExerciseConfig`` instance."""
+    cfg = cli._build_config_from_args(_default_args())
+    assert isinstance(cfg, ExerciseConfig)
+    assert cfg.body_spec.total_mass == pytest.approx(80.0)
+
+
+def test_build_config_from_args_returns_none_on_invalid_mass(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Negative body mass is rejected and logged, returning ``None``."""
+    with caplog.at_level(logging.ERROR, logger=cli.logger.name):
+        result = cli._build_config_from_args(_default_args(body_mass=-1.0))
+    assert result is None
+    assert any("Invalid configuration" in rec.message for rec in caplog.records)
+
+
+def test_build_model_xml_returns_xml_for_known_exercise() -> None:
+    """A successful build produces a non-empty ``<mujoco>`` XML string."""
+    cfg = cli._build_config_from_args(_default_args())
+    assert cfg is not None
+    xml_str = cli._build_model_xml(sorted(EXERCISE_REGISTRY.keys())[0], cfg)
+    assert xml_str is not None
+    assert xml_str.lstrip().startswith("<mujoco") or "<mujoco" in xml_str
+
+
+def test_build_model_xml_returns_none_on_builder_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Builder-raised ``ValueError``/``RuntimeError`` is swallowed -> ``None``."""
+
+    class _BoomBuilder:
+        def __init__(self, _cfg: Any) -> None: ...
+
+        def build(self) -> str:
+            raise RuntimeError("boom")
+
+    target = sorted(EXERCISE_REGISTRY.keys())[0]
+    monkeypatch.setitem(EXERCISE_REGISTRY, target, _BoomBuilder)
+    cfg = ExerciseConfig()
+    with caplog.at_level(logging.ERROR, logger=cli.logger.name):
+        result = cli._build_model_xml(target, cfg)
+    assert result is None
+    assert any("Model build failed" in rec.message for rec in caplog.records)
+
+
+def test_emit_xml_writes_to_stdout_when_output_is_none(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No output path means the XML is written to stdout and exit code is 0."""
+    code = cli._emit_xml("<mujoco/>", output=None)
+    assert code == 0
+    assert capsys.readouterr().out == "<mujoco/>"
+
+
+def test_emit_xml_writes_to_file(tmp_path: Path) -> None:
+    """A provided output path writes the XML to that file."""
+    out = tmp_path / "model.xml"
+    code = cli._emit_xml("<mujoco/>", output=str(out))
+    assert code == 0
+    assert out.read_text(encoding="utf-8") == "<mujoco/>"
+
+
+def test_emit_xml_returns_error_on_unwritable_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """OSError on write yields exit code 1 and is logged."""
+    bogus = "/this/path/does/not/exist/model.xml"
+    with caplog.at_level(logging.ERROR, logger=cli.logger.name):
+        code = cli._emit_xml("<mujoco/>", output=bogus)
+    assert code == 1
+    assert any("Failed to write output file" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Completes the decomposition mandated by issue #122 (A-N 2026-04-10 assessment).

Of the five oversized functions flagged:

| File | Function | Before | After | Status |
|---|---|---|---|---|
| `examples/generate_all_models.py` | `main` | 51 | 16 | Decomposed by #139 |
| `src/mujoco_models/exercises/base.py` | `build` | 46 | 25 | Decomposed by #139 |
| `src/mujoco_models/__main__.py` | `_build_parser` | 45 | 10 | Decomposed by #139 |
| `src/mujoco_models/__main__.py` | `main` | 44 -> 39 | **14** | **Decomposed in this PR** |
| `src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py` | `_post_worldbody_hook` | 44 | 11 | Decomposed by #139 |

PR #139 ("A-N Refresh P1 items batch 1") already handled four of the five targets but left `__main__.main` at 39 LOC, still above the 30-LOC acceptance threshold in the issue. This PR finishes the job.

## Changes

- Split `__main__.main` (39 LOC) into four focused helpers, all <=14 LOC:
  - `_configure_logging(verbose)` -- initialise root logger
  - `_build_config_from_args(args)` -- build `ExerciseConfig` or `None` on invalid anthropometry
  - `_build_model_xml(exercise, config)` -- instantiate builder and call `build()`, returning `None` on builder errors
  - `_emit_xml(xml_str, output)` -- write XML to file or stdout
- `main` now reads as a 14-LOC linear pipeline with explicit early exits.
- Added 9 focused unit tests in `tests/unit/test_cli_helpers.py` covering:
  - Verbose / default logging level forwarding (via `logging.basicConfig` stub)
  - Config build success and invalid-mass failure paths
  - Model XML success and builder-error paths
  - XML emission to stdout, file, and unwritable path

Pure refactor: no observable behaviour change.

## Acceptance criteria

- [x] Each listed function is <=30 LOC (`main` now 14 LOC; others <=25 LOC from #139)
- [x] Extracted helpers each have a single responsibility
- [x] New helpers have unit tests (TDD)
- [x] DbC preconditions documented on public helpers (docstrings)
- [x] No change in observable behavior (existing 650 tests still pass)

## Test plan

- [x] `python3 -m pytest tests/unit/test_cli_helpers.py` -- 13 passed
- [x] `python3 -m pytest -n auto --timeout=60 -m "not slow and not requires_mujoco"` -- 650 passed, 14 skipped (hypothesis import error pre-existing on main, unrelated)
- [x] `ruff check src tests scripts` -- All checks passed
- [x] `ruff format --check src tests scripts` -- 106 files already formatted

Closes #122

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>