### PR TITLE
[codex] Split generate-all reporting seam

### DIFF
--- a/examples/generate_all_models.py
+++ b/examples/generate_all_models.py
@@ -85,22 +85,33 @@ def _iter_unique_builders() -> list[tuple[str, type]]:
     return unique
 
 
-def main() -> None:
+def _generate_models(config: ExerciseConfig, output_dir: str) -> list[str]:
+    """Generate each unique exercise model and return written file paths."""
+    return [
+        _write_model(name, builder_cls, config, output_dir)
+        for name, builder_cls in _iter_unique_builders()
+    ]
+
+
+def _report_generation(paths: list[str], output_dir: str) -> None:
+    """Print generation progress for CLI users."""
+    for out_path in paths:
+        print(f"Wrote {out_path}")
+    print(f"Generated {len(paths)} models in {output_dir}/")
+
+
+def main(argv: list[str] | None = None) -> None:
     """Generate MJCF XML files for all registered exercise models.
 
     Parses command-line arguments and writes one XML file per exercise
     to the configured output directory.
     """
-    args = _build_parser().parse_args()
+    args = _build_parser().parse_args(argv)
     os.makedirs(args.output_dir, exist_ok=True)
 
     config = _build_config(args.body_mass, args.height)
-    unique = _iter_unique_builders()
-    for name, builder_cls in unique:
-        out_path = _write_model(name, builder_cls, config, args.output_dir)
-        print(f"Wrote {out_path}")
-
-    print(f"Generated {len(unique)} models in {args.output_dir}/")
+    paths = _generate_models(config, args.output_dir)
+    _report_generation(paths, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_generate_all_models.py
+++ b/tests/unit/test_generate_all_models.py
@@ -74,3 +74,25 @@ def test_write_model_writes_xml_file(tmp_path) -> None:
     with open(out_path, encoding="utf-8") as fh:
         head = fh.read(200)
     assert "<mujoco" in head
+
+
+def test_generate_models_writes_one_file_per_unique_builder(tmp_path) -> None:
+    """``_generate_models`` keeps generation separate from CLI reporting."""
+    mod = _load_module()
+    cfg = ExerciseConfig()
+
+    paths = mod._generate_models(cfg, str(tmp_path))  # type: ignore[attr-defined]
+
+    assert len(paths) == len(mod._iter_unique_builders())  # type: ignore[attr-defined]
+    assert all(Path(path).exists() for path in paths)
+
+
+def test_main_accepts_explicit_argv(tmp_path, capsys) -> None:
+    """``main`` can be tested without mutating process-level ``sys.argv``."""
+    mod = _load_module()
+
+    mod.main(["--output-dir", str(tmp_path), "--body-mass", "72"])  # type: ignore[attr-defined]
+
+    captured = capsys.readouterr()
+    assert "Generated" in captured.out
+    assert list(tmp_path.glob("*.xml"))


### PR DESCRIPTION
## Summary
- Splits model generation from CLI progress reporting in `examples/generate_all_models.py`.
- Lets `main` accept explicit argv so the CLI path can be tested without mutating global process state.
- Adds regression tests for generation and explicit-argv behavior.

Refs #122

## Validation
- TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/test_generate_all_models.py -q
- python3 -m ruff check examples/generate_all_models.py tests/unit/test_generate_all_models.py
- python3 -m black --check examples/generate_all_models.py tests/unit/test_generate_all_models.py
