### PR TITLE
MuJoCo_Models #129: split bilateral limb body/joint assembly

### DIFF
--- a/src/mujoco_models/shared/body/body_helpers.py
+++ b/src/mujoco_models/shared/body/body_helpers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 
 from mujoco_models.shared.utils.geometry import capsule_inertia
 from mujoco_models.shared.utils.mjcf_helpers import add_body, add_hinge_joint
@@ -24,6 +25,24 @@ _FOOT_CONTACT_SIZE = "0.13 0.05 0.01"
 _FOOT_CONTACT_POS = "0.04 0 -0.02"  # slightly forward and at bottom of foot
 _FOOT_CONTACT_FRICTION = "1.0 0.005 0.0001"  # tangent, torsion, rolling
 _FOOT_CONTACT_RGBA = "0.8 0.6 0.4 0.3"  # semi-transparent for visualization
+
+
+@dataclass(frozen=True)
+class _LimbSideSpec:
+    """Inputs needed to build one side of a bilateral limb."""
+
+    parent_el: ET.Element
+    body_name: str
+    pos: tuple[float, float, float]
+    mass: float
+    inertia: tuple[float, float, float]
+    radius: float
+    length: float
+    coord_prefix: str
+    side: str
+    range_min: float
+    range_max: float
+    extra_joints: _ExtraJoints | None = None
 
 
 def _demote_visual_geom_group(foot_body: ET.Element) -> None:
@@ -81,7 +100,29 @@ def add_foot_contact_geoms(bodies: dict[str, ET.Element]) -> None:
     logger.debug("Added contact sole geometry to foot segments")
 
 
-def _create_limb_side_body(
+def _create_limb_side_body(spec: _LimbSideSpec) -> ET.Element:
+    """Create body and hinge joints for one side of a bilateral limb."""
+    child_body = _build_limb_body(
+        spec.parent_el,
+        body_name=spec.body_name,
+        pos=spec.pos,
+        mass=spec.mass,
+        inertia=spec.inertia,
+        radius=spec.radius,
+        length=spec.length,
+    )
+    _add_limb_joints(
+        child_body,
+        coord_prefix=spec.coord_prefix,
+        side=spec.side,
+        range_min=spec.range_min,
+        range_max=spec.range_max,
+        extra_joints=spec.extra_joints,
+    )
+    return child_body
+
+
+def _build_limb_body(
     parent_el: ET.Element,
     *,
     body_name: str,
@@ -90,14 +131,9 @@ def _create_limb_side_body(
     inertia: tuple[float, float, float],
     radius: float,
     length: float,
-    coord_prefix: str,
-    side: str,
-    range_min: float,
-    range_max: float,
-    extra_joints: _ExtraJoints | None = None,
 ) -> ET.Element:
-    """Create body and hinge joints for one side of a bilateral limb."""
-    child_body = add_body(
+    """Create the capsule body for one side of a bilateral limb."""
+    return add_body(
         parent_el,
         name=body_name,
         pos=pos,
@@ -107,6 +143,18 @@ def _create_limb_side_body(
         geom_size=(radius, length / 2.0),
         geom_rgba="0.8 0.6 0.4 1",
     )
+
+
+def _add_limb_joints(
+    child_body: ET.Element,
+    *,
+    coord_prefix: str,
+    side: str,
+    range_min: float,
+    range_max: float,
+    extra_joints: _ExtraJoints | None = None,
+) -> None:
+    """Attach the flexion joint and any optional side-specific joints."""
     add_hinge_joint(
         child_body,
         name=f"{coord_prefix}_{side}_flex",
@@ -123,7 +171,6 @@ def _create_limb_side_body(
                 range_min=ex_min,
                 range_max=ex_max,
             )
-    return child_body
 
 
 def add_bilateral_limb(
@@ -158,11 +205,10 @@ def add_bilateral_limb(
     parent_is_bilateral = f"{parent_name}_l" in parent_bodies
     created: dict[str, ET.Element] = {}
     for side, sign in [("l", -1.0), ("r", 1.0)]:
-        body_name = f"{seg_name}_{side}"
         key = f"{parent_name}_{side}" if parent_is_bilateral else parent_name
-        created[body_name] = _create_limb_side_body(
-            parent_bodies[key],
-            body_name=body_name,
+        side_spec = _LimbSideSpec(
+            parent_el=parent_bodies[key],
+            body_name=f"{seg_name}_{side}",
             pos=(sign * parent_lateral_x, 0, parent_offset_z),
             mass=mass,
             inertia=inertia,
@@ -174,4 +220,5 @@ def add_bilateral_limb(
             range_max=range_max,
             extra_joints=extra_joints,
         )
+        created[side_spec.body_name] = _create_limb_side_body(side_spec)
     return created

--- a/tests/unit/shared/test_body_helpers_decomposition.py
+++ b/tests/unit/shared/test_body_helpers_decomposition.py
@@ -13,8 +13,12 @@ import xml.etree.ElementTree as ET
 
 from mujoco_models.shared.body import body_helpers
 from mujoco_models.shared.body.body_helpers import (
+    _add_limb_joints,
     _add_single_foot_contact_geom,
+    _build_limb_body,
+    _create_limb_side_body,
     _demote_visual_geom_group,
+    _LimbSideSpec,
     add_foot_contact_geoms,
 )
 
@@ -73,3 +77,80 @@ def test_add_foot_contact_geoms_handles_both_feet() -> None:
 def test_add_foot_contact_geoms_skips_missing_sides() -> None:
     """A dict without the expected keys is tolerated silently (no raise)."""
     add_foot_contact_geoms({})  # must not raise
+
+
+def test_build_limb_body_writes_capsule_body() -> None:
+    """The capsule-body helper should set the body shell and inertial data."""
+    parent = ET.Element("body", name="parent")
+    child = _build_limb_body(
+        parent,
+        body_name="forearm_l",
+        pos=(0.1, 0.2, 0.3),
+        mass=3.5,
+        inertia=(1.0, 2.0, 3.0),
+        radius=0.04,
+        length=0.5,
+    )
+
+    assert child.get("name") == "forearm_l"
+    assert child.get("pos") == "0.100000 0.200000 0.300000"
+    inertial = child.find("inertial")
+    assert inertial is not None
+    assert inertial.get("mass") == "3.500000"
+    assert inertial.get("diaginertia") == "1.000000 2.000000 3.000000"
+    geom = child.find("geom")
+    assert geom is not None
+    assert geom.get("type") == "capsule"
+    assert geom.get("size") == "0.040000 0.250000"
+
+
+def test_add_limb_joints_writes_primary_and_extra_joints() -> None:
+    """The joint helper should attach the flexion joint and side-specific extras."""
+    body = ET.Element("body", name="hand_r")
+
+    _add_limb_joints(
+        body,
+        coord_prefix="wrist",
+        side="r",
+        range_min=-1.0,
+        range_max=1.0,
+        extra_joints=[
+            ("deviate", (0, 0, 1), -0.5, 0.5),
+        ],
+    )
+
+    joints = body.findall("joint")
+    assert [joint.get("name") for joint in joints] == [
+        "wrist_r_flex",
+        "wrist_r_deviate",
+    ]
+    assert joints[0].get("type") == "hinge"
+    assert joints[0].get("axis") == "1.000000 0.000000 0.000000"
+    assert joints[0].get("range") == "-1.0000 1.0000"
+    assert joints[1].get("axis") == "0.000000 0.000000 1.000000"
+    assert joints[1].get("range") == "-0.5000 0.5000"
+
+
+def test_create_limb_side_body_composes_body_and_joints() -> None:
+    """The orchestration helper should keep the body and joint wiring together."""
+    parent = ET.Element("body", name="upper_arm_l")
+    spec = _LimbSideSpec(
+        parent_el=parent,
+        body_name="forearm_l",
+        pos=(0.0, 0.0, -0.3),
+        mass=2.0,
+        inertia=(0.1, 0.2, 0.3),
+        radius=0.03,
+        length=0.4,
+        coord_prefix="elbow",
+        side="l",
+        range_min=0.0,
+        range_max=2.618,
+        extra_joints=None,
+    )
+
+    child = _create_limb_side_body(spec)
+
+    assert child.get("name") == "forearm_l"
+    assert child.find("geom") is not None
+    assert [joint.get("name") for joint in child.findall("joint")] == ["elbow_l_flex"]


### PR DESCRIPTION
Addresses a bounded slice of issue #129 by decomposing the bilateral limb helper wiring in src/mujoco_models/shared/body/body_helpers.py.

What changed:
- split one helper into smaller body and joint helpers
- added focused pytest coverage for each extracted helper
- kept the higher-level body assembly behavior covered by the existing body-model tests

Validation:
- /tmp/mujoco_models_ci/bin/pytest tests/unit/shared/test_body_helpers_decomposition.py tests/unit/shared/test_body_model.py -q
- /tmp/mujoco_models_ci/bin/ruff check src/mujoco_models/shared/body/body_helpers.py tests/unit/shared/test_body_helpers_decomposition.py
- /tmp/mujoco_models_ci/bin/mypy src/mujoco_models/shared/body/body_helpers.py tests/unit/shared/test_body_helpers_decomposition.py
- /tmp/mujoco_models_ci/bin/black --check src/mujoco_models/shared/body/body_helpers.py tests/unit/shared/test_body_helpers_decomposition.py