### PR TITLE
[codex] refactor barbell hand attachment helper

### DIFF
--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -165,6 +165,38 @@ class ExerciseModelBuilder(ABC):
         empty method in an ABC that is not itself abstract).
         """
 
+    @staticmethod
+    def _barbell_relpose_for_hand(
+        side: str,
+        grip_width: float | None = None,
+        grip_offset: tuple[float, ...] | None = None,
+    ) -> tuple[float, ...] | None:
+        """Return the weld relpose for one hand.
+
+        ``grip_offset`` wins when provided. Otherwise, ``grip_width`` is
+        converted into a left/right X offset anchored at the hand.
+        """
+        if grip_offset is not None:
+            return grip_offset
+        if grip_width is None:
+            return None
+
+        sign = -1.0 if side == "l" else 1.0
+        return (-sign * grip_width, 0, 0, 1, 0, 0, 0)
+
+    @staticmethod
+    def _attach_barbell_to_hand(
+        equality: ET.Element, *, side: str, relpose: tuple[float, ...] | None
+    ) -> None:
+        """Write one hand weld to the shared equality section."""
+        add_weld_constraint(
+            equality,
+            name=f"barbell_to_hand_{side}",
+            body1=f"hand_{side}",
+            body2="barbell_shaft",
+            relpose=relpose,
+        )
+
     def _attach_barbell_to_hands(
         self,
         equality: ET.Element,
@@ -185,20 +217,11 @@ class ExerciseModelBuilder(ABC):
             Optional 7-element relative pose (x y z qw qx qy qz) for the grip
             offset from the hand to the barbell shaft.
         """
-        for side, sign in [("l", -1.0), ("r", 1.0)]:
-            relpose = grip_offset
-            if relpose is None and grip_width is not None:
-                # Left hand (side="l", sign=-1) is at -X relative to barbell center.
-                # relpose defines barbell center relative to hand, so it's at +X.
-                relpose = (-sign * grip_width, 0, 0, 1, 0, 0, 0)
-
-            add_weld_constraint(
-                equality,
-                name=f"barbell_to_hand_{side}",
-                body1=f"hand_{side}",
-                body2="barbell_shaft",
-                relpose=relpose,
+        for side in ("l", "r"):
+            relpose = self._barbell_relpose_for_hand(
+                side, grip_width=grip_width, grip_offset=grip_offset
             )
+            self._attach_barbell_to_hand(equality, side=side, relpose=relpose)
 
     # ------------------------------------------------------------------
     # Shared pose helper (issue #116)

--- a/tests/unit/exercises/test_base.py
+++ b/tests/unit/exercises/test_base.py
@@ -194,3 +194,38 @@ class TestBuildDecomposition:
         bad_root = ET.Element("notmujoco")
         with pytest.raises(ValueError, match="MJCF root"):
             builder._finalize_model(bad_root)
+
+
+class TestBarbellAttachmentHelpers:
+    """Tests for the barbell-to-hands helpers extracted in A-N Refresh 2026-04-14."""
+
+    def test_barbell_relpose_for_hand_uses_grip_offset(self) -> None:
+        """An explicit grip offset should win over any grip width."""
+        offset = (0.010, 0.020, 0.030, 1.0, 0.0, 0.0, 0.0)
+        relpose = ForwardingBuilder._barbell_relpose_for_hand(
+            "l", grip_width=0.4, grip_offset=offset
+        )
+        assert relpose == offset
+
+    def test_barbell_relpose_for_hand_uses_width_per_side(self) -> None:
+        """Grip width is converted into mirrored left/right weld offsets."""
+        left = ForwardingBuilder._barbell_relpose_for_hand("l", grip_width=0.4)
+        right = ForwardingBuilder._barbell_relpose_for_hand("r", grip_width=0.4)
+        assert left == (0.4, 0, 0, 1, 0, 0, 0)
+        assert right == (-0.4, 0, 0, 1, 0, 0, 0)
+
+    def test_attach_barbell_to_hands_writes_welds_for_each_side(self) -> None:
+        """The helper should still emit one weld per hand with the derived pose."""
+        builder = ForwardingBuilder(ExerciseConfig())
+        equality = ET.Element("equality")
+
+        builder._attach_barbell_to_hands(equality, grip_width=0.4)
+
+        welds = {w.get("name"): w for w in equality.findall("weld")}
+        assert set(welds) == {"barbell_to_hand_l", "barbell_to_hand_r"}
+        assert welds["barbell_to_hand_l"].get("relpose") == (
+            "0.400000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000"
+        )
+        assert welds["barbell_to_hand_r"].get("relpose") == (
+            "-0.400000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000"
+        )


### PR DESCRIPTION
Refs #129.

Split the shared barbell-to-hands attachment path into two small helpers so the relpose calculation and weld creation each stay focused. The behavior is unchanged: explicit grip offsets still win, and grip width still expands to mirrored left/right welds.

Checks:
- .venv/bin/ruff check src/mujoco_models/exercises/base.py tests/unit/exercises/test_base.py
- .venv/bin/ruff format --check src/mujoco_models/exercises/base.py tests/unit/exercises/test_base.py
- QT_QPA_PLATFORM=offscreen .venv/bin/pytest tests/unit/exercises/test_base.py -q
- QT_QPA_PLATFORM=offscreen .venv/bin/pytest tests/integration/test_all_exercises_build.py -q