### PR TITLE
refactor: split foot contact body iteration

### DIFF
--- a/src/mujoco_models/shared/body/body_helpers.py
+++ b/src/mujoco_models/shared/body/body_helpers.py
@@ -76,6 +76,17 @@ def _add_single_foot_contact_geom(foot_body: ET.Element, side: str) -> None:
     contact_geom.set("rgba", _FOOT_CONTACT_RGBA)
 
 
+def _iter_foot_bodies(
+    bodies: dict[str, ET.Element],
+) -> tuple[tuple[str, ET.Element], ...]:
+    """Return present foot bodies keyed by side, skipping missing unilateral feet."""
+    return tuple(
+        (side, foot_body)
+        for side in ("l", "r")
+        if (foot_body := bodies.get(f"foot_{side}")) is not None
+    )
+
+
 def add_foot_contact_geoms(bodies: dict[str, ET.Element]) -> None:
     """Add box collision geometry to foot segments for ground contact.
 
@@ -90,10 +101,7 @@ def add_foot_contact_geoms(bodies: dict[str, ET.Element]) -> None:
     Missing sides (e.g. unilateral rigs) are silently skipped; callers
     that require a specific side should check ``bodies`` themselves.
     """
-    for side in ("l", "r"):
-        foot_body = bodies.get(f"foot_{side}")
-        if foot_body is None:
-            continue
+    for side, foot_body in _iter_foot_bodies(bodies):
         _demote_visual_geom_group(foot_body)
         _add_single_foot_contact_geom(foot_body, side)
 

--- a/tests/unit/shared/test_contact_model.py
+++ b/tests/unit/shared/test_contact_model.py
@@ -9,6 +9,7 @@ from mujoco_models.exercises.bench_press.bench_press_model import (
 )
 from mujoco_models.exercises.squat.squat_model import build_squat_model
 from mujoco_models.shared.body import create_full_body
+from mujoco_models.shared.body.body_helpers import _iter_foot_bodies
 
 
 class TestFootContactGeometry:
@@ -81,6 +82,10 @@ class TestFootContactGeometry:
             assert size_parts[0] == pytest.approx(0.13)
             assert size_parts[1] == pytest.approx(0.05)
             assert size_parts[2] == pytest.approx(0.01)
+
+    def test_iter_foot_bodies_skips_missing_unilateral_feet(self) -> None:
+        left = ET.Element("body", name="foot_l")
+        assert _iter_foot_bodies({"foot_l": left}) == (("l", left),)
 
 
 class TestContactExclusions:


### PR DESCRIPTION
## Summary
- extract foot-body discovery from contact-geometry mutation
- add coverage for unilateral/missing-foot behavior so callers can safely skip absent sides

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_contact_model.py -q`
- `python3 -m ruff check src/mujoco_models/shared/body/body_helpers.py tests/unit/shared/test_contact_model.py`
- `python3 -m black --check src/mujoco_models/shared/body/body_helpers.py tests/unit/shared/test_contact_model.py`

Refs #129
