### PR TITLE
refactor: split generate all reporting

### DIFF
--- a/examples/generate_all_models.py
+++ b/examples/generate_all_models.py
@@ -95,9 +95,16 @@ def _generate_models(config: ExerciseConfig, output_dir: str) -> list[str]:
 
 def _report_generation(paths: list[str], output_dir: str) -> None:
     """Print generation progress for CLI users."""
-    for out_path in paths:
-        print(f"Wrote {out_path}")
-    print(f"Generated {len(paths)} models in {output_dir}/")
+    for line in _format_generation_report(paths, output_dir):
+        print(line)
+
+
+def _format_generation_report(paths: list[str], output_dir: str) -> list[str]:
+    """Return user-facing generation report lines for written model paths."""
+    return [
+        *(f"Wrote {out_path}" for out_path in paths),
+        f"Generated {len(paths)} models in {output_dir}/",
+    ]
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/unit/test_generate_all_models.py
+++ b/tests/unit/test_generate_all_models.py
@@ -87,6 +87,19 @@ def test_generate_models_writes_one_file_per_unique_builder(tmp_path) -> None:
     assert all(Path(path).exists() for path in paths)
 
 
+def test_format_generation_report_lists_paths_and_summary() -> None:
+    """``_format_generation_report`` is pure formatting for CLI output."""
+    mod = _load_module()
+
+    lines = mod._format_generation_report(["out/a.xml", "out/b.xml"], "out")  # type: ignore[attr-defined]
+
+    assert lines == [
+        "Wrote out/a.xml",
+        "Wrote out/b.xml",
+        "Generated 2 models in out/",
+    ]
+
+
 def test_main_accepts_explicit_argv(tmp_path, capsys) -> None:
     """``main`` can be tested without mutating process-level ``sys.argv``."""
     mod = _load_module()


### PR DESCRIPTION
## Summary
- extract generate-all CLI report formatting into a pure helper
- add focused coverage for generated progress and summary lines

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/test_generate_all_models.py -q`
- `python3 -m ruff check examples/generate_all_models.py tests/unit/test_generate_all_models.py`
- `python3 -m black --check examples/generate_all_models.py tests/unit/test_generate_all_models.py`

Refs #129
