### PR TITLE
chore: add requirements.txt and module docstrings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Core dependencies for MuJoCo Models
+# Generated from pyproject.toml dependencies
+
+numpy>=1.26.4,<3.0.0
+matplotlib>=3.7.0
+mujoco>=3.3.0

--- a/src/mujoco_models/exercises/bench_press/__init__.py
+++ b/src/mujoco_models/exercises/bench_press/__init__.py
@@ -1,0 +1,5 @@
+"""Bench press exercise model builder.
+
+Provides MuJoCo MJCF model generation for horizontal barbell press exercises,
+including biomechanical analysis and kinematic parameters.
+"""

--- a/src/mujoco_models/exercises/clean_and_jerk/__init__.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/__init__.py
@@ -1,0 +1,5 @@
+"""Clean and jerk exercise model builder.
+
+Provides MuJoCo MJCF model generation for Olympic weightlifting clean and jerk
+movements, with complete kinematic and dynamic analysis.
+"""

--- a/src/mujoco_models/exercises/deadlift/__init__.py
+++ b/src/mujoco_models/exercises/deadlift/__init__.py
@@ -1,0 +1,5 @@
+"""Deadlift exercise model builder.
+
+Provides MuJoCo MJCF model generation for deadlift exercises,
+with biomechanical parameters and kinematic constraints.
+"""

--- a/src/mujoco_models/exercises/snatch/__init__.py
+++ b/src/mujoco_models/exercises/snatch/__init__.py
@@ -1,0 +1,5 @@
+"""Snatch exercise model builder.
+
+Provides MuJoCo MJCF model generation for Olympic weightlifting snatch movements,
+with complete kinematic and dynamic analysis.
+"""

--- a/src/mujoco_models/exercises/squat/__init__.py
+++ b/src/mujoco_models/exercises/squat/__init__.py
@@ -1,0 +1,5 @@
+"""Squat exercise model builder.
+
+Provides MuJoCo MJCF model generation for barbell squat exercises,
+with biomechanical parameters and kinematic constraints.
+"""


### PR DESCRIPTION
## Summary
- W5-5011: Add requirements.txt with core dependencies (numpy, matplotlib, mujoco) extracted from pyproject.toml
- W5-5013: Add comprehensive module docstrings to exercise submodules (bench_press, clean_and_jerk, deadlift, snatch)

## Test plan
- [ ] CI passes
- [ ] requirements.txt matches pyproject.toml dependencies