### PR TITLE
docs: add module-level docstrings to empty __init__.py files (#182)

### DIFF
--- a/src/mujoco_models/__init__.py
+++ b/src/mujoco_models/__init__.py
@@ -1,0 +1,1 @@
+"""MuJoCo Models — biomechanical exercise models for MuJoCo simulation."""

--- a/src/mujoco_models/shared/__init__.py
+++ b/src/mujoco_models/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities and contracts used across the MuJoCo Models package."""

--- a/src/mujoco_models/shared/contracts/__init__.py
+++ b/src/mujoco_models/shared/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Shared contracts and preconditions for MuJoCo model validation."""

--- a/src/mujoco_models/shared/utils/__init__.py
+++ b/src/mujoco_models/shared/utils/__init__.py
@@ -1,0 +1,1 @@
+"""General-purpose utility functions for MuJoCo Models."""


### PR DESCRIPTION
Fixes #182

Adds missing module-level docstrings to the four empty `__init__.py` files in the src-layout packages:

- `src/mujoco_models/__init__.py`
- `src/mujoco_models/shared/__init__.py`
- `src/mujoco_models/shared/contracts/__init__.py`
- `src/mujoco_models/shared/utils/__init__.py`

These files were previously empty and therefore lacked module-level documentation. This change improves package discoverability and satisfies lint/doc checks that flag missing docstrings.