### PR TITLE
[assess-N] Add SPDX-License-Identifier and DCO enforcement (closes #190, #339)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,64 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `ci`, `chore`.
 3. Request review from at least one maintainer.
 4. Squash merge when approved.
 
+## Developer Certificate of Origin (DCO)
+
+By contributing to this project, you agree to the following terms:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+### Sign-off Requirement
+
+All commits must be signed off using `git commit -s`. This adds a
+`Signed-off-by:` line to your commit message. For example:
+
+```bash
+git commit -s -m "feat: add new exercise model"
+```
+
+If you have already made commits without sign-off, amend them:
+
+```bash
+git rebase --signoff HEAD~N
+```
+
+Where `N` is the number of commits to amend. Then force-push to your
+fork (never to `main`).
+
 ## Code Style
 
 - Follow PEP 8 (enforced by ruff).

--- a/SPEC.md
+++ b/SPEC.md
@@ -105,7 +105,18 @@ The CI contract is defined in `.github/workflows/ci-standard.yml` and currently 
 
 Local validation should follow the same shape as CI when changes affect source behavior. Documentation-only changes should still keep the spec truthful and aligned with the current tree.
 
-## 8. Maintenance Rules
+## 8. Licensing
+
+All Python source files in `src/` include an SPDX license header:
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+```
+
+This header is present in every module-level `.py` file as of the SPDX header update.
+
+## 9. Maintenance Rules
 
 - Keep `SPEC.md` aligned with the actual package layout and supported entrypoints.
 - Update the spec whenever the public model-generation surface changes.

--- a/src/mujoco_models/__init__.py
+++ b/src/mujoco_models/__init__.py
@@ -1,1 +1,5 @@
 """MuJoCo Models — biomechanical exercise models for MuJoCo simulation."""
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/__init__.py
+++ b/src/mujoco_models/__init__.py
@@ -2,4 +2,3 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import argparse

--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -1,5 +1,9 @@
 """CLI entry point for ``python -m mujoco_models <exercise> [options]``."""
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import argparse

--- a/src/mujoco_models/exercises/__init__.py
+++ b/src/mujoco_models/exercises/__init__.py
@@ -7,7 +7,6 @@ for programmatic discovery.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mujoco_models/exercises/__init__.py
+++ b/src/mujoco_models/exercises/__init__.py
@@ -4,6 +4,10 @@ Provides a registry mapping exercise names to their builder classes
 for programmatic discovery.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -9,6 +9,10 @@ Law of Demeter: Exercise builders interact with BarbellSpec and BodyModelSpec
 through their public APIs, never reaching into internal segment tables.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/base.py
+++ b/src/mujoco_models/exercises/base.py
@@ -12,7 +12,6 @@ through their public APIs, never reaching into internal segment tables.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/bench_press/__init__.py
+++ b/src/mujoco_models/exercises/bench_press/__init__.py
@@ -6,4 +6,3 @@ including biomechanical analysis and kinematic parameters.
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/exercises/bench_press/__init__.py
+++ b/src/mujoco_models/exercises/bench_press/__init__.py
@@ -3,3 +3,7 @@
 Provides MuJoCo MJCF model generation for horizontal barbell press exercises,
 including biomechanical analysis and kinematic parameters.
 """
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -16,6 +16,10 @@ pelvis to a supine position at bench height (0.43 m, standard IPF).
 MuJoCo Z-up convention: gravity = (0, 0, -9.80665).
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/bench_press/bench_press_model.py
+++ b/src/mujoco_models/exercises/bench_press/bench_press_model.py
@@ -19,7 +19,6 @@ MuJoCo Z-up convention: gravity = (0, 0, -9.80665).
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/clean_and_jerk/__init__.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/__init__.py
@@ -3,3 +3,7 @@
 Provides MuJoCo MJCF model generation for Olympic weightlifting clean and jerk
 movements, with complete kinematic and dynamic analysis.
 """
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/exercises/clean_and_jerk/__init__.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/__init__.py
@@ -6,4 +6,3 @@ movements, with complete kinematic and dynamic analysis.
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -29,7 +29,6 @@ The barbell is welded to both hands at clean grip width.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/mujoco_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -26,6 +26,10 @@ Biomechanical notes:
 The barbell is welded to both hands at clean grip width.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/deadlift/__init__.py
+++ b/src/mujoco_models/exercises/deadlift/__init__.py
@@ -6,4 +6,3 @@ with biomechanical parameters and kinematic constraints.
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/exercises/deadlift/__init__.py
+++ b/src/mujoco_models/exercises/deadlift/__init__.py
@@ -3,3 +3,7 @@
 Provides MuJoCo MJCF model generation for deadlift exercises,
 with biomechanical parameters and kinematic constraints.
 """
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -16,6 +16,10 @@ The barbell is welded to both hands. Initial pose has significant hip
 and knee flexion to reach the bar on the ground.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/deadlift/deadlift_model.py
+++ b/src/mujoco_models/exercises/deadlift/deadlift_model.py
@@ -19,7 +19,6 @@ and knee flexion to reach the bar on the ground.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/gait/__init__.py
+++ b/src/mujoco_models/exercises/gait/__init__.py
@@ -1,5 +1,9 @@
 """Gait (walking) exercise model builder."""
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from mujoco_models.exercises.gait.gait_model import (
     GaitModelBuilder,
     build_gait_model,

--- a/src/mujoco_models/exercises/gait/__init__.py
+++ b/src/mujoco_models/exercises/gait/__init__.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from mujoco_models.exercises.gait.gait_model import (
     GaitModelBuilder,
     build_gait_model,

--- a/src/mujoco_models/exercises/gait/gait_model.py
+++ b/src/mujoco_models/exercises/gait/gait_model.py
@@ -12,6 +12,10 @@ Biomechanical notes:
 - MuJoCo Z-up convention: gravity = (0, 0, -9.80665)
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/gait/gait_model.py
+++ b/src/mujoco_models/exercises/gait/gait_model.py
@@ -15,7 +15,6 @@ Biomechanical notes:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/sit_to_stand/__init__.py
+++ b/src/mujoco_models/exercises/sit_to_stand/__init__.py
@@ -1,5 +1,9 @@
 """Sit-to-stand exercise model builder."""
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from mujoco_models.exercises.sit_to_stand.sit_to_stand_model import (
     SitToStandModelBuilder,
     build_sit_to_stand_model,

--- a/src/mujoco_models/exercises/sit_to_stand/__init__.py
+++ b/src/mujoco_models/exercises/sit_to_stand/__init__.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from mujoco_models.exercises.sit_to_stand.sit_to_stand_model import (
     SitToStandModelBuilder,
     build_sit_to_stand_model,

--- a/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -12,6 +12,10 @@ Biomechanical notes:
 - MuJoCo Z-up convention: gravity = (0, 0, -9.80665)
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/mujoco_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -15,7 +15,6 @@ Biomechanical notes:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/snatch/__init__.py
+++ b/src/mujoco_models/exercises/snatch/__init__.py
@@ -6,4 +6,3 @@ with complete kinematic and dynamic analysis.
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/exercises/snatch/__init__.py
+++ b/src/mujoco_models/exercises/snatch/__init__.py
@@ -3,3 +3,7 @@
 Provides MuJoCo MJCF model generation for Olympic weightlifting snatch movements,
 with complete kinematic and dynamic analysis.
 """
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -25,7 +25,6 @@ The barbell is welded to both hands with a wide grip offset.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/snatch/snatch_model.py
+++ b/src/mujoco_models/exercises/snatch/snatch_model.py
@@ -22,6 +22,10 @@ Biomechanical notes:
 The barbell is welded to both hands with a wide grip offset.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/squat/__init__.py
+++ b/src/mujoco_models/exercises/squat/__init__.py
@@ -6,4 +6,3 @@ with biomechanical parameters and kinematic constraints.
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/exercises/squat/__init__.py
+++ b/src/mujoco_models/exercises/squat/__init__.py
@@ -3,3 +3,7 @@
 Provides MuJoCo MJCF model generation for barbell squat exercises,
 with biomechanical parameters and kinematic constraints.
 """
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/exercises/squat/squat_model.py
+++ b/src/mujoco_models/exercises/squat/squat_model.py
@@ -12,6 +12,10 @@ Biomechanical notes:
 - MuJoCo Z-up convention: gravity = (0, 0, -9.80665)
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/exercises/squat/squat_model.py
+++ b/src/mujoco_models/exercises/squat/squat_model.py
@@ -15,7 +15,6 @@ Biomechanical notes:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/__init__.py
+++ b/src/mujoco_models/optimization/__init__.py
@@ -7,7 +7,6 @@ and inverse kinematics keyframe generation for MuJoCo barbell exercise models.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/__init__.py
+++ b/src/mujoco_models/optimization/__init__.py
@@ -4,6 +4,10 @@ Provides exercise-specific optimization objectives, trajectory optimization,
 and inverse kinematics keyframe generation for MuJoCo barbell exercise models.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/exercise_objective_data.py
+++ b/src/mujoco_models/optimization/exercise_objective_data.py
@@ -6,6 +6,10 @@ This file is kept for backward compatibility.
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.bench_press import (

--- a/src/mujoco_models/optimization/exercise_objective_data.py
+++ b/src/mujoco_models/optimization/exercise_objective_data.py
@@ -9,7 +9,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.bench_press import (

--- a/src/mujoco_models/optimization/exercise_objective_data_aux.py
+++ b/src/mujoco_models/optimization/exercise_objective_data_aux.py
@@ -6,6 +6,10 @@ This file is kept for backward compatibility.
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.clean_and_jerk import (

--- a/src/mujoco_models/optimization/exercise_objective_data_aux.py
+++ b/src/mujoco_models/optimization/exercise_objective_data_aux.py
@@ -9,7 +9,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.clean_and_jerk import (

--- a/src/mujoco_models/optimization/exercise_objective_data_functional.py
+++ b/src/mujoco_models/optimization/exercise_objective_data_functional.py
@@ -9,7 +9,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.functional import (

--- a/src/mujoco_models/optimization/exercise_objective_data_functional.py
+++ b/src/mujoco_models/optimization/exercise_objective_data_functional.py
@@ -6,6 +6,10 @@ This file is kept for backward compatibility.
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.functional import (

--- a/src/mujoco_models/optimization/exercise_objectives.py
+++ b/src/mujoco_models/optimization/exercise_objectives.py
@@ -13,7 +13,6 @@ Design by Contract:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/exercise_objectives.py
+++ b/src/mujoco_models/optimization/exercise_objectives.py
@@ -10,6 +10,10 @@ Design by Contract:
     - Each exercise has a valid bar path constraint and balance mode.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/inverse_kinematics.py
+++ b/src/mujoco_models/optimization/inverse_kinematics.py
@@ -13,7 +13,6 @@ Design by Contract:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/inverse_kinematics.py
+++ b/src/mujoco_models/optimization/inverse_kinematics.py
@@ -10,6 +10,10 @@ Design by Contract:
     - Output keyframes have shape (n_frames, n_joints).
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/objective_data/__init__.py
+++ b/src/mujoco_models/optimization/objective_data/__init__.py
@@ -5,6 +5,10 @@ for a single exercise or small group of related movements.  All joint
 angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.bench_press import (

--- a/src/mujoco_models/optimization/objective_data/__init__.py
+++ b/src/mujoco_models/optimization/objective_data/__init__.py
@@ -8,7 +8,6 @@ angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.objective_data.bench_press import (

--- a/src/mujoco_models/optimization/objective_data/bench_press.py
+++ b/src/mujoco_models/optimization/objective_data/bench_press.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/bench_press.py
+++ b/src/mujoco_models/optimization/objective_data/bench_press.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/clean_and_jerk.py
+++ b/src/mujoco_models/optimization/objective_data/clean_and_jerk.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/clean_and_jerk.py
+++ b/src/mujoco_models/optimization/objective_data/clean_and_jerk.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/deadlift.py
+++ b/src/mujoco_models/optimization/objective_data/deadlift.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/deadlift.py
+++ b/src/mujoco_models/optimization/objective_data/deadlift.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/functional.py
+++ b/src/mujoco_models/optimization/objective_data/functional.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/functional.py
+++ b/src/mujoco_models/optimization/objective_data/functional.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/shared_poses.py
+++ b/src/mujoco_models/optimization/objective_data/shared_poses.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 STANDING_POSE: dict[str, float] = {

--- a/src/mujoco_models/optimization/objective_data/shared_poses.py
+++ b/src/mujoco_models/optimization/objective_data/shared_poses.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 STANDING_POSE: dict[str, float] = {

--- a/src/mujoco_models/optimization/objective_data/snatch.py
+++ b/src/mujoco_models/optimization/objective_data/snatch.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/snatch.py
+++ b/src/mujoco_models/optimization/objective_data/snatch.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/squat.py
+++ b/src/mujoco_models/optimization/objective_data/squat.py
@@ -6,7 +6,6 @@ All joint angles are in radians.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/objective_data/squat.py
+++ b/src/mujoco_models/optimization/objective_data/squat.py
@@ -3,6 +3,10 @@
 All joint angles are in radians.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from mujoco_models.optimization.exercise_objectives import (

--- a/src/mujoco_models/optimization/polygon_geometry.py
+++ b/src/mujoco_models/optimization/polygon_geometry.py
@@ -4,6 +4,10 @@ Provides point-in-polygon tests and point-to-polygon distance
 calculations used by the trajectory optimizer's balance cost function.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/src/mujoco_models/optimization/polygon_geometry.py
+++ b/src/mujoco_models/optimization/polygon_geometry.py
@@ -7,7 +7,6 @@ calculations used by the trajectory optimizer's balance cost function.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import numpy as np

--- a/src/mujoco_models/optimization/trajectory_optimizer.py
+++ b/src/mujoco_models/optimization/trajectory_optimizer.py
@@ -8,6 +8,10 @@ Design by Contract:
     - Config values are validated for physical plausibility.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/optimization/trajectory_optimizer.py
+++ b/src/mujoco_models/optimization/trajectory_optimizer.py
@@ -11,7 +11,6 @@ Design by Contract:
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/__init__.py
+++ b/src/mujoco_models/shared/__init__.py
@@ -1,1 +1,5 @@
 """Shared utilities and contracts used across the MuJoCo Models package."""
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/shared/__init__.py
+++ b/src/mujoco_models/shared/__init__.py
@@ -2,4 +2,3 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/shared/barbell/__init__.py
+++ b/src/mujoco_models/shared/barbell/__init__.py
@@ -7,7 +7,6 @@ with correct mass, geometry, and inertia properties.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from mujoco_models.shared.barbell.barbell_model import (
     BarbellSpec,
     create_barbell_bodies,

--- a/src/mujoco_models/shared/barbell/__init__.py
+++ b/src/mujoco_models/shared/barbell/__init__.py
@@ -4,6 +4,10 @@ Provides factory functions to create standard Olympic barbell bodies
 with correct mass, geometry, and inertia properties.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from mujoco_models.shared.barbell.barbell_model import (
     BarbellSpec,
     create_barbell_bodies,

--- a/src/mujoco_models/shared/barbell/barbell_model.py
+++ b/src/mujoco_models/shared/barbell/barbell_model.py
@@ -15,6 +15,10 @@ Law of Demeter: callers interact only with BarbellSpec and create_barbell_bodies
 internal geometry details remain encapsulated.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/barbell/barbell_model.py
+++ b/src/mujoco_models/shared/barbell/barbell_model.py
@@ -18,7 +18,6 @@ internal geometry details remain encapsulated.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/__init__.py
+++ b/src/mujoco_models/shared/body/__init__.py
@@ -4,6 +4,10 @@ Provides a simplified but anatomically grounded full-body model with
 major body segments and joints suitable for barbell exercise simulation.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from mujoco_models.shared.body.body_anthropometrics import (
     BodyModelSpec,
 )

--- a/src/mujoco_models/shared/body/__init__.py
+++ b/src/mujoco_models/shared/body/__init__.py
@@ -7,7 +7,6 @@ major body segments and joints suitable for barbell exercise simulation.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from mujoco_models.shared.body.body_anthropometrics import (
     BodyModelSpec,
 )

--- a/src/mujoco_models/shared/body/axial_skeleton.py
+++ b/src/mujoco_models/shared/body/axial_skeleton.py
@@ -10,7 +10,6 @@ Extracted from body_model.py to keep modules under the 300-line guideline.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/axial_skeleton.py
+++ b/src/mujoco_models/shared/body/axial_skeleton.py
@@ -7,6 +7,10 @@ of the musculoskeletal model.
 Extracted from body_model.py to keep modules under the 300-line guideline.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/body_anthropometrics.py
+++ b/src/mujoco_models/shared/body/body_anthropometrics.py
@@ -11,7 +11,6 @@ The leg-height fraction constant is defined here so that both the spec's
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mujoco_models/shared/body/body_anthropometrics.py
+++ b/src/mujoco_models/shared/body/body_anthropometrics.py
@@ -8,6 +8,10 @@ The leg-height fraction constant is defined here so that both the spec's
 ``pelvis_height`` property and the MJCF assembly layer share one source of truth.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/mujoco_models/shared/body/body_helpers.py
+++ b/src/mujoco_models/shared/body/body_helpers.py
@@ -3,6 +3,10 @@
 Extracted from body_model.py to keep modules under the 300-line budget.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/body/body_helpers.py
+++ b/src/mujoco_models/shared/body/body_helpers.py
@@ -6,7 +6,6 @@ Extracted from body_model.py to keep modules under the 300-line budget.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/body/body_model.py
+++ b/src/mujoco_models/shared/body/body_model.py
@@ -11,6 +11,10 @@ Public API (re-exported for backward compatibility):
     BodyModelSpec, _LEG_HEIGHT_FRACTION, create_full_body
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/body/body_model.py
+++ b/src/mujoco_models/shared/body/body_model.py
@@ -14,7 +14,6 @@ Public API (re-exported for backward compatibility):
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/body/lower_limbs.py
+++ b/src/mujoco_models/shared/body/lower_limbs.py
@@ -7,6 +7,10 @@ contact geometry for ground interaction.
 Extracted from body_model.py to keep modules under the 300-line guideline.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/lower_limbs.py
+++ b/src/mujoco_models/shared/body/lower_limbs.py
@@ -10,7 +10,6 @@ Extracted from body_model.py to keep modules under the 300-line guideline.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/segment_data.py
+++ b/src/mujoco_models/shared/body/segment_data.py
@@ -9,7 +9,6 @@ Extracted from body_model.py to keep modules under the 300-line guideline.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/body/segment_data.py
+++ b/src/mujoco_models/shared/body/segment_data.py
@@ -6,6 +6,10 @@ body height for a simplified musculoskeletal model.
 Extracted from body_model.py to keep modules under the 300-line guideline.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/body/upper_limbs.py
+++ b/src/mujoco_models/shared/body/upper_limbs.py
@@ -6,6 +6,10 @@ forming the complete upper-limb kinematic chains.
 Extracted from body_model.py to keep modules under the 300-line guideline.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/body/upper_limbs.py
+++ b/src/mujoco_models/shared/body/upper_limbs.py
@@ -9,7 +9,6 @@ Extracted from body_model.py to keep modules under the 300-line guideline.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/contracts/__init__.py
+++ b/src/mujoco_models/shared/contracts/__init__.py
@@ -1,1 +1,5 @@
 """Shared contracts and preconditions for MuJoCo model validation."""
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/shared/contracts/__init__.py
+++ b/src/mujoco_models/shared/contracts/__init__.py
@@ -2,4 +2,3 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/shared/contracts/postconditions.py
+++ b/src/mujoco_models/shared/contracts/postconditions.py
@@ -4,6 +4,10 @@ Used to validate outputs after computation -- catches bugs in model
 generation before they propagate to downstream MJCF XML or simulation.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/contracts/postconditions.py
+++ b/src/mujoco_models/shared/contracts/postconditions.py
@@ -7,7 +7,6 @@ generation before they propagate to downstream MJCF XML or simulation.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET

--- a/src/mujoco_models/shared/contracts/preconditions.py
+++ b/src/mujoco_models/shared/contracts/preconditions.py
@@ -8,7 +8,6 @@ accept invalid geometry or physics parameters.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/contracts/preconditions.py
+++ b/src/mujoco_models/shared/contracts/preconditions.py
@@ -5,6 +5,10 @@ Violations raise ValueError with descriptive messages -- never silently
 accept invalid geometry or physics parameters.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/parity/__init__.py
+++ b/src/mujoco_models/shared/parity/__init__.py
@@ -1,1 +1,5 @@
 """Cross-repo parity standard for biomechanical parameters."""
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/shared/parity/__init__.py
+++ b/src/mujoco_models/shared/parity/__init__.py
@@ -2,4 +2,3 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/shared/parity/standard.py
+++ b/src/mujoco_models/shared/parity/standard.py
@@ -5,6 +5,10 @@ OpenSim repos.  Any deviation breaks cross-repo parity and must be
 justified.
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/parity/standard.py
+++ b/src/mujoco_models/shared/parity/standard.py
@@ -8,7 +8,6 @@ justified.
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import math

--- a/src/mujoco_models/shared/theme.py
+++ b/src/mujoco_models/shared/theme.py
@@ -1,5 +1,9 @@
 """Shared plotting theme configuration."""
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/theme.py
+++ b/src/mujoco_models/shared/theme.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/utils/__init__.py
+++ b/src/mujoco_models/shared/utils/__init__.py
@@ -1,1 +1,5 @@
 """General-purpose utility functions for MuJoCo Models."""
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+

--- a/src/mujoco_models/shared/utils/__init__.py
+++ b/src/mujoco_models/shared/utils/__init__.py
@@ -2,4 +2,3 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
-

--- a/src/mujoco_models/shared/utils/geometry.py
+++ b/src/mujoco_models/shared/utils/geometry.py
@@ -10,7 +10,6 @@ Cylinder axis aligned with Z-axis (MuJoCo default for capsule/cylinder).
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/utils/geometry.py
+++ b/src/mujoco_models/shared/utils/geometry.py
@@ -7,6 +7,10 @@ MuJoCo convention: Z-up, gravity = (0, 0, -9.80665).
 Cylinder axis aligned with Z-axis (MuJoCo default for capsule/cylinder).
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -9,7 +9,6 @@ MuJoCo MJCF reference: https://mujoco.readthedocs.io/en/stable/XMLreference.html
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
 
-
 from __future__ import annotations
 
 import logging

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -6,6 +6,10 @@ so that MJCF structure is defined in exactly one place.
 MuJoCo MJCF reference: https://mujoco.readthedocs.io/en/stable/XMLreference.html
 """
 
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Closes #190 and #339

## Changes
- Added `SPDX-License-Identifier: MIT` and copyright headers to all 54 Python source files under `src/`
- Added DCO (Developer Certificate of Origin) section to `CONTRIBUTING.md` with:
  - Full DCO v1.1 text
  - Sign-off requirement with `git commit -s` examples
  - Instructions for amending existing commits with `git rebase --signoff`

## Verification
- All source files now have SPDX headers: `grep -r 'SPDX-License-Identifier' src/ | wc -l` = 54
- CONTRIBUTING.md includes DCO sign-off requirement
- No functional code changes — headers and documentation only

## Checklist
- [x] SPDX headers added to all source files
- [x] DCO section added to CONTRIBUTING.md
- [x] Conventional commit format used