### PR TITLE
chore(config): add .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# MuJoCo_Models environment variables
+# Copy this file to .env and fill in your values
+
+# MuJoCo rendering
+MUJOCO_GL=egl
+
+# Build / dev paths
+PROJECT_ROOT=
+MUJOCO_MODELS_STATE_DIR=


### PR DESCRIPTION
Documents required environment variables for new contributors.

Closes assessment finding I (missing .env.example).