### PR TITLE
fix(tests): add requires_mujoco marker to integration tests (#183)

### DIFF
--- a/tests/integration/test_mujoco_loading.py
+++ b/tests/integration/test_mujoco_loading.py
@@ -47,6 +47,7 @@ _IDS = [n for n, _ in ALL_BUILDERS]
 
 
 @_SKIP_MUJOCO
+@pytest.mark.requires_mujoco
 class TestMuJoCoLoading:
     @pytest.mark.parametrize("name,builder", ALL_BUILDERS, ids=_IDS)
     def test_model_loads_without_error(self, name: str, builder: Any) -> None:

--- a/tests/unit/shared/test_hypothesis_properties.py
+++ b/tests/unit/shared/test_hypothesis_properties.py
@@ -12,10 +12,6 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import pytest
 
-hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, settings
-from hypothesis import strategies as st
-
 from mujoco_models.shared.body import BodyModelSpec, create_full_body
 from mujoco_models.shared.body.segment_data import SEGMENT_TABLE, segment_properties
 from mujoco_models.shared.utils.geometry import (
@@ -24,6 +20,10 @@ from mujoco_models.shared.utils.geometry import (
     rectangular_prism_inertia,
     sphere_inertia,
 )
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
 
 # Strategies for physically plausible ranges
 positive_float = st.floats(min_value=0.01, max_value=1e4, allow_nan=False)


### PR DESCRIPTION
## Summary

Fixes #183 by adding the `@pytest.mark.requires_mujoco` marker to the integration test class.

## Problem
The CI workflow filters tests with `-m "not requires_mujoco"`, but the `TestMuJoCoLoading` class in `tests/integration/test_mujoco_loading.py` only had `@pytest.mark.skipif(...)` and not the actual `requires_mujoco` marker. This meant:
- CI filter `not requires_mujoco` was not actively excluding these tests
- Instead they were being skipped silently by `skipif`, which is less transparent

## Changes
- Added `@pytest.mark.requires_mujoco` to the `TestMuJoCoLoading` class alongside the existing `@_SKIP_MUJOCO` skipif
- Now CI filtering and local test selection behave consistently
- Tests are properly deselected by the marker system rather than silently skipped

## Verification
- `pytest -m "not requires_mujoco"` → 14 tests deselected ✓
- `pytest -m "requires_mujoco"` → 14 tests collected ✓

## Checklist
- [x] Marker added alongside existing skipif
- [x] Tests collected/deselected correctly with both marker filters
- [x] Conventional commit format followed