### PR TITLE
fix: add console-script entry point and make package installable (closes #179)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -36,9 +36,10 @@ The shared barbell layer lives in `shared/barbell/barbell_model.py` and builds t
 
 ## 4. Public Interface
 
-The supported entrypoint is module execution:
+The supported entrypoints are module execution and the package console script:
 
 - `python -m mujoco_models <exercise> [options]`
+- `mujoco-models <exercise> [options]`
 
 The CLI is implemented in `src/mujoco_models/__main__.py` and builds models from:
 
@@ -84,7 +85,7 @@ The model-building APIs accept plain dataclass configuration rather than implici
 - All lengths are expressed in meters and all masses in kilograms.
 - MuJoCo uses a Z-up convention in this repository: gravity is `(0.0, 0.0, -9.80665)`.
 
-The repo does not currently define a package console script. `python -m mujoco_models` is the stable runtime entrypoint.
+The package also exposes `mujoco-models` as a console script via `[project.scripts]` in `pyproject.toml`. Both entrypoints are functionally equivalent.
 
 ## 7. Testing And CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dev = [
     "pytest-benchmark>=4.0.0",
 ]
 
+
+[project.scripts]
+mujoco-models = "mujoco_models.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/D-sorganization/MuJoCo_Models"
 Repository = "https://github.com/D-sorganization/MuJoCo_Models"

--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
-"""CLI entry point for ``python -m mujoco_models <exercise> [options]``."""
+
+"""CLI entry point for ``python -m mujoco_models`` or ``mujoco-models``."""
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization


### PR DESCRIPTION
- Add [project.scripts] section to pyproject.toml:
    mujoco-models = 'mujoco_models.__main__:main'
- After Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/dieterolson/Linux_Repositories/Linux_MuJoCo_Models/MuJoCo_Models
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: matplotlib>=3.7.0 in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco-models==0.1.0) (3.10.8)
Requirement already satisfied: mujoco>=3.3.0 in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco-models==0.1.0) (3.8.0)
Requirement already satisfied: numpy<3.0.0,>=1.26.4 in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco-models==0.1.0) (2.2.6)
Requirement already satisfied: contourpy>=1.0.1 in /home/dieterolson/.local/lib/python3.10/site-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (1.3.2)
Requirement already satisfied: cycler>=0.10 in /usr/lib/python3/dist-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (0.11.0)
Requirement already satisfied: fonttools>=4.22.0 in /usr/lib/python3/dist-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (4.29.1)
Requirement already satisfied: kiwisolver>=1.3.1 in /usr/lib/python3/dist-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (1.3.2)
Requirement already satisfied: packaging>=20.0 in /home/dieterolson/.local/lib/python3.10/site-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (26.2)
Requirement already satisfied: pillow>=8 in /usr/lib/python3/dist-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (9.0.1)
Requirement already satisfied: pyparsing>=3 in /home/dieterolson/.local/lib/python3.10/site-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (3.3.2)
Requirement already satisfied: python-dateutil>=2.7 in /home/dieterolson/.local/lib/python3.10/site-packages (from matplotlib>=3.7.0->mujoco-models==0.1.0) (2.9.0.post0)
Requirement already satisfied: absl-py in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco>=3.3.0->mujoco-models==0.1.0) (2.4.0)
Requirement already satisfied: etils[epath] in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco>=3.3.0->mujoco-models==0.1.0) (1.13.0)
Requirement already satisfied: glfw in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco>=3.3.0->mujoco-models==0.1.0) (2.10.0)
Requirement already satisfied: pyopengl in /home/dieterolson/.local/lib/python3.10/site-packages (from mujoco>=3.3.0->mujoco-models==0.1.0) (3.1.10)
Requirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.7->matplotlib>=3.7.0->mujoco-models==0.1.0) (1.16.0)
Requirement already satisfied: fsspec in /home/dieterolson/.local/lib/python3.10/site-packages (from etils[epath]->mujoco>=3.3.0->mujoco-models==0.1.0) (2026.2.0)
Requirement already satisfied: importlib_resources in /home/dieterolson/.local/lib/python3.10/site-packages (from etils[epath]->mujoco>=3.3.0->mujoco-models==0.1.0) (6.5.2)
Requirement already satisfied: typing_extensions in /home/dieterolson/.local/lib/python3.10/site-packages (from etils[epath]->mujoco>=3.3.0->mujoco-models==0.1.0) (4.15.0)
Requirement already satisfied: zipp in /home/dieterolson/.local/lib/python3.10/site-packages (from etils[epath]->mujoco>=3.3.0->mujoco-models==0.1.0) (3.23.1)
Building wheels for collected packages: mujoco-models
  Building editable for mujoco-models (pyproject.toml): started
  Building editable for mujoco-models (pyproject.toml): finished with status 'done'
  Created wheel for mujoco-models: filename=mujoco_models-0.1.0-py3-none-any.whl size=3781 sha256=dae87307d7169a4d2b27fea44e16128e3f348225424139d76d519f6b03a8dbf6
  Stored in directory: /tmp/pip-ephem-wheel-cache-btgepiyc/wheels/60/18/54/ade74984a5b13b9de9d0161f0961ceb4076668b43edbeb8a5f
Successfully built mujoco-models
Installing collected packages: mujoco-models
  Attempting uninstall: mujoco-models
    Found existing installation: mujoco-models 0.1.0
    Uninstalling mujoco-models-0.1.0:
      Successfully uninstalled mujoco-models-0.1.0
Successfully installed mujoco-models-0.1.0, both 
  and  CLI commands work without PYTHONPATH.