### PR TITLE
ci: add smoke test verifying python -m mujoco_models works without PYTHONPATH

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -118,6 +118,13 @@ jobs:
       - name: Install Dependencies
         run: pip install -e ".[dev]"
 
+      - name: Verify package is importable without PYTHONPATH
+        run: |
+          python3 -m mujoco_models --help >/dev/null 2>&1 || {
+            echo "::error::Package not importable after pip install. Check pyproject.toml build config."
+            exit 1
+          }
+
       - name: Run Test Suite
         run: |
           python3 -m pytest \


### PR DESCRIPTION
Adds a CI step that runs `python3 -m mujoco_models --help` after `pip install -e .[dev]` to confirm the package is properly registered in the venv and does not require a PYTHONPATH workaround.\n\nFixes #179