### PR TITLE
feat(exceptions): add domain-specific exception hierarchy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -47,6 +47,14 @@ The CLI is implemented in `src/mujoco_models/__main__.py` and builds models from
 - `BarbellSpec`
 - `EXERCISE_REGISTRY`
 
+The package root also re-exports the public exception hierarchy for callers that
+need stable failure handling without importing internal modules:
+
+- `MuJoCoModelError`
+- `ModelBuildError`
+- `ValidationError`
+- `PreconditionError`
+
 The registry in `src/mujoco_models/exercises/__init__.py` exposes the supported builders and aliases:
 
 - `squat` and `back_squat`

--- a/src/mujoco_models/__init__.py
+++ b/src/mujoco_models/__init__.py
@@ -3,3 +3,17 @@
 
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 D-sorganization
+
+from mujoco_models.exceptions import (
+    ModelBuildError,
+    MuJoCoModelError,
+    PreconditionError,
+    ValidationError,
+)
+
+__all__ = [
+    "MuJoCoModelError",
+    "ModelBuildError",
+    "ValidationError",
+    "PreconditionError",
+]

--- a/src/mujoco_models/exceptions.py
+++ b/src/mujoco_models/exceptions.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+"""Domain-specific exception hierarchy for MuJoCo Models.
+
+All public exceptions inherit from :class:`MuJoCoModelError` so callers can
+catch every model-related failure with a single ``except`` clause.
+"""
+
+from __future__ import annotations
+
+
+class MuJoCoModelError(Exception):
+    """Base exception for all model-related errors."""
+
+    pass
+
+
+class ModelBuildError(MuJoCoModelError):
+    """Raised when an MJCF model cannot be constructed."""
+
+    pass
+
+
+class ValidationError(MuJoCoModelError):
+    """Raised when input parameters fail domain validation."""
+
+    pass
+
+
+class PreconditionError(MuJoCoModelError):
+    """Raised when a runtime precondition is violated."""
+
+    pass

--- a/src/mujoco_models/exceptions.py
+++ b/src/mujoco_models/exceptions.py
@@ -11,22 +11,14 @@ from __future__ import annotations
 class MuJoCoModelError(Exception):
     """Base exception for all model-related errors."""
 
-    pass
-
 
 class ModelBuildError(MuJoCoModelError):
     """Raised when an MJCF model cannot be constructed."""
-
-    pass
 
 
 class ValidationError(MuJoCoModelError):
     """Raised when input parameters fail domain validation."""
 
-    pass
-
 
 class PreconditionError(MuJoCoModelError):
     """Raised when a runtime precondition is violated."""
-
-    pass


### PR DESCRIPTION
Introduces MuJoCoModelError base class with ModelBuildError, ValidationError, and PreconditionError subclasses. All exceptions are re-exported from the package root so callers can import them directly.\n\nFixes #177