### PR TITLE
ci(security): add CycloneDX SBOM generation and artifact upload

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Generate SBOM
         run: |
           pip install cyclonedx-bom
-          cyclonedx-py environment --outfile sbom.json --output-format JSON
+          cyclonedx-py environment -o sbom.json --output-format JSON
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Generate SBOM
         run: |
           pip install cyclonedx-bom
-          cyclonedx-py -e -o sbom.json
+          cyclonedx-py environment --outfile sbom.json --output-format JSON
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -91,6 +91,17 @@ jobs:
         run: |
           bandit -r src/ -ll -ii --format txt
 
+      - name: Generate SBOM
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py -e -o sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json
+
     needs: pick-runner
   tests:
     needs:


### PR DESCRIPTION
Generates a CycloneDX SBOM from the editable install and uploads it as a CI artifact for supply-chain transparency and security auditing.\n\nFixes #186