### PR TITLE
ci: add retry with backoff for self-hosted runner check

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -22,15 +22,32 @@ permissions:
 jobs:
   pick-runner:
     runs-on: d-sorg-fleet
-    timeout-minutes: 2
+    timeout-minutes: 5
     outputs:
       runner: ${{ steps.check.outputs.runner }}
     steps:
-      - name: Check for self-hosted runner
+      - name: Check for self-hosted runner with retry
         id: check
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-        run: "ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \\\n  --jq '[.runners[] | select(.status == \"online\") | select(.labels[].name == \"d-sorg-fleet\")] | length' \\\n  2>/dev/null || echo \"0\")\nif [[ \"$ONLINE\" -gt 0 ]]; then\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"Self-hosted runner online — routing locally\"\nelse\n  echo \"runner=ubuntu-latest\" >> $GITHUB_OUTPUT\n  echo \"No self-hosted runner — using GitHub-hosted\"\nfi"
+        run: |
+          for attempt in 1 2 3; do
+            ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
+              --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \
+              2>/dev/null || echo "0")
+            if [[ "$ONLINE" =~ ^[0-9]+$ && "$ONLINE" -gt 0 ]]; then
+              echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
+              echo "Self-hosted runner online — routing locally (attempt $attempt)"
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              echo "No self-hosted runner online — retrying in 15s (attempt $attempt/3)"
+              sleep 15
+            fi
+          done
+          echo "::warning::No self-hosted runner after 3 attempts; falling back to GitHub-hosted"
+          echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+          echo "No self-hosted runner — using GitHub-hosted"
   quality-gate:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
ci: add retry with backoff for self-hosted runner check

Adds a 3-attempt retry loop with 15s delays to the pick-runner job.

- 3 attempts with 15s sleep between retries
- timeout increased from 2 to 5 minutes
- proper numeric validation before comparison
- warning annotation on fallback to ubuntu-latest

Closes #174
