### PR TITLE
fix(ci): correct dtolnay rust action name

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The CI workflow was referencing `dtolnay/rust-action@stable` which does not exist as a GitHub Action. The correct and widely-used action name is `dtolnay/rust-toolchain@stable`.

**Changes:**
- Fixed `.github/workflows/ci-standard.yml` line 125: changed `dtolnay/rust-action@stable` → `dtolnay/rust-toolchain@stable`

**Impact:**
- Fixes the `rust` job in CI Standard workflow that was failing with: `Unable to resolve action dtolnay/rust-action, repository not found`
- No functional code changes

Closes the CI fragility issue where Rust builds fail on every run.