### PR TITLE
fix: enforce cyclomatic complexity (McCabe) in CI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -116,6 +116,7 @@ Testing is organized around unit, integration, and parity coverage under `tests/
 The CI contract is defined in `.github/workflows/ci-standard.yml` and currently includes:
 
 - `ruff check src scripts tests` (line length enforced at 88 characters)
+- cyclomatic complexity (McCabe) enforcement via `ruff` rule `C90` with a max complexity of 10
 - `ruff format --check src scripts tests`
 - `mypy src --config-file pyproject.toml`
 - `pytest` with coverage enforcement at 80% on the source tree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,13 +65,16 @@ target-version = "py310"
 select = [
     "E", "F", "I", "UP", "B", "T201", "SIM",
     "C4", "PIE", "PLE", "FURB", "RSE", "LOG",
-    "PERF", "RET",
+    "PERF", "RET", "C90",
 ]
 ignore = [
     "RET504",
     "PERF203",
     "PERF401",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/**" = ["T201"]


### PR DESCRIPTION
Addresses issue #187 by enabling the C90 (McCabe) complexity check in Ruff with a threshold of 10.