### PR TITLE
fix: add docker-compose.yml for containerized deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  mujoco-models:
+    build: .
+    volumes:
+      - .:/workspace
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    environment:
+      - DISPLAY=${DISPLAY:-:0}
+      - MUJOCO_GL=egl
+    network_mode: host
+    command: python -m mujoco_models


### PR DESCRIPTION
Adds docker-compose.yml for reproducible deployment and development environments.

## Changes
- Added docker-compose.yml with workspace mount, X11 forwarding, and MuJoCo EGL rendering

Addresses P2 finding: No Dockerfile or container support from the A-O comprehensive health assessment.