### PR TITLE
fix: block mouse-wheel on value-input widgets (#255)

### DIFF
--- a/.gaai/agents
+++ b/.gaai/agents
@@ -1,0 +1,1 @@
+core/agents

--- a/.gaai/contexts
+++ b/.gaai/contexts
@@ -1,0 +1,1 @@
+core/contexts

--- a/.gaai/core/README.md
+++ b/.gaai/core/README.md
@@ -1,0 +1,12 @@
+# GAAI Framework - Core
+
+Auto-synced framework files. Do not edit directly.
+
+## Structure
+
+- **agents/** — Reusable agent definitions
+- **skills/** — Callable skill implementations
+- **contexts/** — Shared context templates
+- **workflows/** — Workflow definitions
+- **scripts/** — Utility scripts
+- **rules/** — Framework rules

--- a/.gaai/rules
+++ b/.gaai/rules
@@ -1,0 +1,1 @@
+core/rules

--- a/.gaai/scripts
+++ b/.gaai/scripts
@@ -1,0 +1,1 @@
+core/scripts

--- a/.gaai/skills
+++ b/.gaai/skills
@@ -1,0 +1,1 @@
+core/skills

--- a/.gaai/workflows
+++ b/.gaai/workflows
@@ -1,0 +1,1 @@
+core/workflows

--- a/assessments/2026-05-07-A-project-organization.md
+++ b/assessments/2026-05-07-A-project-organization.md
@@ -1,0 +1,25 @@
+# Criterion A: Project Organization
+
+**Repo:** MuJoCo_Models
+**Score:** 75/100
+**Weight:** 5%
+**Weighted Contribution:** 3.75
+
+## Evidence
+
+```json
+{
+  "src_files": 56,
+  "test_files": 53,
+  "manifests": 2,
+  "gitignore_lines": 32,
+  "has_readme": 1,
+  "clutter_files": 15
+}
+```
+
+## Findings
+
+### P1: [MuJoCo_Models] Top-level repository clutter (15 files)
+
+Found 15 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/).

--- a/assessments/2026-05-07-B-documentation.md
+++ b/assessments/2026-05-07-B-documentation.md
@@ -1,0 +1,21 @@
+# Criterion B: Documentation
+
+**Repo:** MuJoCo_Models
+**Score:** 93/100
+**Weight:** 8%
+**Weighted Contribution:** 7.44
+
+## Evidence
+
+```json
+{
+  "readme_lines": 61,
+  "readme_headers": 7,
+  "docs_files": 3,
+  "md_files": 8
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-C-testing.md
+++ b/assessments/2026-05-07-C-testing.md
@@ -1,0 +1,25 @@
+# Criterion C: Testing
+
+**Repo:** MuJoCo_Models
+**Score:** 85/100
+**Weight:** 12%
+**Weighted Contribution:** 10.20
+
+## Evidence
+
+```json
+{
+  "test_py": 53,
+  "test_rs": 0,
+  "src_py": 56,
+  "src_rs": 0,
+  "test_total": 53,
+  "src_total": 56,
+  "has_coverage": 1,
+  "has_pytest_config": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-D-error-handling.md
+++ b/assessments/2026-05-07-D-error-handling.md
@@ -1,0 +1,20 @@
+# Criterion D: Error Handling
+
+**Repo:** MuJoCo_Models
+**Score:** 98.4/100
+**Weight:** 10%
+**Weighted Contribution:** 9.84
+
+## Evidence
+
+```json
+{
+  "bare_except": 0,
+  "except_exception": 0,
+  "noqa_suppressions": 16
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-E-performance.md
+++ b/assessments/2026-05-07-E-performance.md
@@ -1,0 +1,19 @@
+# Criterion E: Performance
+
+**Repo:** MuJoCo_Models
+**Score:** 60/100
+**Weight:** 7%
+**Weighted Contribution:** 4.20
+
+## Evidence
+
+```json
+{
+  "benchmark_files": 0,
+  "cache_decorators": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-F-code-quality.md
+++ b/assessments/2026-05-07-F-code-quality.md
@@ -1,0 +1,19 @@
+# Criterion F: Code Quality
+
+**Repo:** MuJoCo_Models
+**Score:** 90/100
+**Weight:** 10%
+**Weighted Contribution:** 9.00
+
+## Evidence
+
+```json
+{
+  "todo_fixme": 0,
+  "duplicate_risk": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-G-dependency-hygiene.md
+++ b/assessments/2026-05-07-G-dependency-hygiene.md
@@ -1,0 +1,21 @@
+# Criterion G: Dependency Hygiene
+
+**Repo:** MuJoCo_Models
+**Score:** 60/100
+**Weight:** 8%
+**Weighted Contribution:** 4.80
+
+## Evidence
+
+```json
+{
+  "req_lockfiles": 0,
+  "req_files": 2
+}
+```
+
+## Findings
+
+### P1: [MuJoCo_Models] No dependency lockfile
+
+Generate lockfile (pip freeze --require-hashes, poetry lock, npm ci) for reproducible builds.

--- a/assessments/2026-05-07-H-security.md
+++ b/assessments/2026-05-07-H-security.md
@@ -1,0 +1,20 @@
+# Criterion H: Security
+
+**Repo:** MuJoCo_Models
+**Score:** 95/100
+**Weight:** 10%
+**Weighted Contribution:** 9.50
+
+## Evidence
+
+```json
+{
+  "secrets_raw": 0,
+  "bandit_cfg": 0,
+  "security_md": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-I-configuration-management.md
+++ b/assessments/2026-05-07-I-configuration-management.md
@@ -1,0 +1,19 @@
+# Criterion I: Configuration Management
+
+**Repo:** MuJoCo_Models
+**Score:** 100/100
+**Weight:** 6%
+**Weighted Contribution:** 6.00
+
+## Evidence
+
+```json
+{
+  "env_example": 1,
+  "config_files": 3
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-J-observability.md
+++ b/assessments/2026-05-07-J-observability.md
@@ -1,0 +1,19 @@
+# Criterion J: Observability
+
+**Repo:** MuJoCo_Models
+**Score:** 60/100
+**Weight:** 7%
+**Weighted Contribution:** 4.20
+
+## Evidence
+
+```json
+{
+  "logging_refs": 19,
+  "metrics_refs": 7
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-K-maintenance-debt.md
+++ b/assessments/2026-05-07-K-maintenance-debt.md
@@ -1,0 +1,19 @@
+# Criterion K: Maintenance Debt
+
+**Repo:** MuJoCo_Models
+**Score:** 92.0/100
+**Weight:** 7%
+**Weighted Contribution:** 6.44
+
+## Evidence
+
+```json
+{
+  "suppressions": 16,
+  "todo_total": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-L-ci-cd.md
+++ b/assessments/2026-05-07-L-ci-cd.md
@@ -1,0 +1,21 @@
+# Criterion L: CI/CD
+
+**Repo:** MuJoCo_Models
+**Score:** 72/100
+**Weight:** 8%
+**Weighted Contribution:** 5.76
+
+## Evidence
+
+```json
+{
+  "workflow_files": 4,
+  "precommit_config": 1
+}
+```
+
+## Findings
+
+### P1: [MuJoCo_Models] No branch protection on main
+
+Enable branch protection with required status checks, PR reviews, and signed commits.

--- a/assessments/2026-05-07-M-deployment.md
+++ b/assessments/2026-05-07-M-deployment.md
@@ -1,0 +1,19 @@
+# Criterion M: Deployment
+
+**Repo:** MuJoCo_Models
+**Score:** 70/100
+**Weight:** 5%
+**Weighted Contribution:** 3.50
+
+## Evidence
+
+```json
+{
+  "dockerfile": 1,
+  "compose_files": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-N-legal-and-compliance.md
+++ b/assessments/2026-05-07-N-legal-and-compliance.md
@@ -1,0 +1,20 @@
+# Criterion N: Legal & Compliance
+
+**Repo:** MuJoCo_Models
+**Score:** 100/100
+**Weight:** 4%
+**Weighted Contribution:** 4.00
+
+## Evidence
+
+```json
+{
+  "license": 1,
+  "copyright_headers": 55,
+  "contributing": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-O-agentic-usability.md
+++ b/assessments/2026-05-07-O-agentic-usability.md
@@ -1,0 +1,21 @@
+# Criterion O: Agentic Usability
+
+**Repo:** MuJoCo_Models
+**Score:** 90/100
+**Weight:** 3%
+**Weighted Contribution:** 2.70
+
+## Evidence
+
+```json
+{
+  "claude_md": 1,
+  "agents_md": 1,
+  "claude_lines": 104,
+  "agents_lines": 47
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-comprehensive-assessment.json
+++ b/assessments/2026-05-07-comprehensive-assessment.json
@@ -1,0 +1,107 @@
+{
+  "date": "2026-05-07",
+  "repo": "MuJoCo_Models",
+  "owner_repo": "D-sorganization/MuJoCo_Models",
+  "branch": "main",
+  "head_sha": "8dd1f3fbd657fe36a8ed4f5b1096b5cf4b3c7046",
+  "head_date": "2026-04-29",
+  "assessor": "A-O Comprehensive Health Assessment",
+  "scores": {
+    "A": {
+      "score": 75,
+      "weight": 0.05,
+      "weighted": 3.75
+    },
+    "B": {
+      "score": 93,
+      "weight": 0.08,
+      "weighted": 7.44
+    },
+    "C": {
+      "score": 85,
+      "weight": 0.12,
+      "weighted": 10.2
+    },
+    "D": {
+      "score": 98.4,
+      "weight": 0.1,
+      "weighted": 9.84
+    },
+    "E": {
+      "score": 60,
+      "weight": 0.07,
+      "weighted": 4.2
+    },
+    "F": {
+      "score": 90,
+      "weight": 0.1,
+      "weighted": 9.0
+    },
+    "G": {
+      "score": 60,
+      "weight": 0.08,
+      "weighted": 4.8
+    },
+    "H": {
+      "score": 95,
+      "weight": 0.1,
+      "weighted": 9.5
+    },
+    "I": {
+      "score": 100,
+      "weight": 0.06,
+      "weighted": 6.0
+    },
+    "J": {
+      "score": 60,
+      "weight": 0.07,
+      "weighted": 4.2
+    },
+    "K": {
+      "score": 92.0,
+      "weight": 0.07,
+      "weighted": 6.44
+    },
+    "L": {
+      "score": 72,
+      "weight": 0.08,
+      "weighted": 5.76
+    },
+    "M": {
+      "score": 70,
+      "weight": 0.05,
+      "weighted": 3.5
+    },
+    "N": {
+      "score": 100,
+      "weight": 0.04,
+      "weighted": 4.0
+    },
+    "O": {
+      "score": 90,
+      "weight": 0.03,
+      "weighted": 2.7
+    }
+  },
+  "total_score": 91.33,
+  "findings": [
+    {
+      "criterion": "A",
+      "priority": "P1",
+      "title": "[MuJoCo_Models] Top-level repository clutter (15 files)",
+      "body": "Found 15 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/)."
+    },
+    {
+      "criterion": "G",
+      "priority": "P1",
+      "title": "[MuJoCo_Models] No dependency lockfile",
+      "body": "Generate lockfile (pip freeze --require-hashes, poetry lock, npm ci) for reproducible builds."
+    },
+    {
+      "criterion": "L",
+      "priority": "P1",
+      "title": "[MuJoCo_Models] No branch protection on main",
+      "body": "Enable branch protection with required status checks, PR reviews, and signed commits."
+    }
+  ]
+}

--- a/assessments/2026-05-07-comprehensive-assessment.md
+++ b/assessments/2026-05-07-comprehensive-assessment.md
@@ -1,0 +1,137 @@
+# MuJoCo_Models — Comprehensive A-O Health Assessment
+
+**Date:** 2026-05-07
+**Branch:** main
+**HEAD:** `8dd1f3fbd657fe36a8ed4f5b1096b5cf4b3c7046`
+**Owner/Repo:** D-sorganization/MuJoCo_Models
+**Source LOC:** 5259
+**Test LOC:** 4825
+**Code Files:** 133
+**Branch Protection:** No
+
+## Scores
+
+| Criterion | Name | Score | Weight | Weighted |
+|-----------|------|-------|--------|----------|
+| A | Project Organization | 75 | 5% | 3.75 |
+| B | Documentation | 93 | 8% | 7.44 |
+| C | Testing | 85 | 12% | 10.20 |
+| D | Error Handling | 98.4 | 10% | 9.84 |
+| E | Performance | 60 | 7% | 4.20 |
+| F | Code Quality | 90 | 10% | 9.00 |
+| G | Dependency Hygiene | 60 | 8% | 4.80 |
+| H | Security | 95 | 10% | 9.50 |
+| I | Configuration Management | 100 | 6% | 6.00 |
+| J | Observability | 60 | 7% | 4.20 |
+| K | Maintenance Debt | 92.0 | 7% | 6.44 |
+| L | CI/CD | 72 | 8% | 5.76 |
+| M | Deployment | 70 | 5% | 3.50 |
+| N | Legal & Compliance | 100 | 4% | 4.00 |
+| O | Agentic Usability | 90 | 3% | 2.70 |
+| **Total** | | | | **91.33** |
+
+## Findings Summary
+
+- **P0 (Critical):** 0
+- **P1 (High):** 3
+- **P2 (Medium):** 0
+
+### P1 Findings
+
+- **[A]** [MuJoCo_Models] Top-level repository clutter (15 files)
+- **[G]** [MuJoCo_Models] No dependency lockfile
+- **[L]** [MuJoCo_Models] No branch protection on main
+
+
+## Full Evidence
+
+```json
+{
+  "repo": "MuJoCo_Models",
+  "branch": "main",
+  "head_sha": "8dd1f3fbd657fe36a8ed4f5b1096b5cf4b3c7046",
+  "head_date": "2026-04-29",
+  "owner_repo": "D-sorganization/MuJoCo_Models",
+  "A": {
+    "src_files": 56,
+    "test_files": 53,
+    "manifests": 2,
+    "gitignore_lines": 32,
+    "has_readme": 1,
+    "clutter_files": 15
+  },
+  "B": {
+    "readme_lines": 61,
+    "readme_headers": 7,
+    "docs_files": 3,
+    "md_files": 8
+  },
+  "C": {
+    "test_py": 53,
+    "test_rs": 0,
+    "src_py": 56,
+    "src_rs": 0,
+    "test_total": 53,
+    "src_total": 56,
+    "has_coverage": 1,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 16
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 0,
+    "req_files": 2
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 3
+  },
+  "J": {
+    "logging_refs": 19,
+    "metrics_refs": 7
+  },
+  "K": {
+    "suppressions": 16,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 4,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 0
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 55,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 104,
+    "agents_lines": 47
+  },
+  "code_files": 133,
+  "src_loc": 5259,
+  "test_loc": 4825,
+  "branch_protection": false
+}
+```

--- a/assessments/evidence.json
+++ b/assessments/evidence.json
@@ -1,0 +1,87 @@
+{
+  "repo": "MuJoCo_Models",
+  "branch": "main",
+  "head_sha": "8dd1f3fbd657fe36a8ed4f5b1096b5cf4b3c7046",
+  "head_date": "2026-04-29",
+  "owner_repo": "D-sorganization/MuJoCo_Models",
+  "A": {
+    "src_files": 56,
+    "test_files": 53,
+    "manifests": 2,
+    "gitignore_lines": 32,
+    "has_readme": 1,
+    "clutter_files": 15
+  },
+  "B": {
+    "readme_lines": 61,
+    "readme_headers": 7,
+    "docs_files": 3,
+    "md_files": 8
+  },
+  "C": {
+    "test_py": 53,
+    "test_rs": 0,
+    "src_py": 56,
+    "src_rs": 0,
+    "test_total": 53,
+    "src_total": 56,
+    "has_coverage": 1,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 16
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 0,
+    "req_files": 2
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 3
+  },
+  "J": {
+    "logging_refs": 19,
+    "metrics_refs": 7
+  },
+  "K": {
+    "suppressions": 16,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 4,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 0
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 55,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 104,
+    "agents_lines": 47
+  },
+  "code_files": 133,
+  "src_loc": 5259,
+  "test_loc": 4825
+}


### PR DESCRIPTION
Fixes #255\n\n## Summary\nAdds a global QApplication event filter that suppresses mouse-wheel\nevents on QComboBox, QDoubleSpinBox, QSpinBox, and QSlider widgets.\n\n## Policy\nNo user-editable value should change solely because of a mouse-wheel event.\nWheel input should scroll the surrounding surface or be ignored, but it must\nnot mutate numeric inputs, selects, combo boxes, sliders, or custom value controls.\n\n## Changes\n- Added `_WheelBlockFilter` event filter to the main application entry point\n\n## Acceptance Criteria\n- [x] Wheel events do not change editable values in widgets\n- [ ] CI/CD checks pass