### PR TITLE
⚡ Bolt: Optimize relpose string formatting in add_weld_constraint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,7 @@
 ## 2024-05-07 - Avoid Nested ElementTree `iter()` Traversal
 **Learning:** Using nested `xml.etree.ElementTree.iter()` calls creates expensive O(N*M) tree traversals. In methods like `_build_keyframe` in `mujoco_models/exercises/base.py`, this causes significant unnecessary overhead.
 **Action:** Instead of iterating through all children for every element, iterate over potential parent elements once (O(M)) and use `.find()` to locate specific children efficiently while preserving document order.
+
+## 2026-04-26 - Optimize MJCF XML string formatting for relpose
+**Learning:** Similar to `geom_size` and `geom_euler`, using generator expressions within `"".join()` for `relpose` (which is typically a 7-tuple) incurs unnecessary generator allocation overhead.
+**Action:** Extend the hardcoded string formatting optimization to `relpose` for length 7 to avoid generator overhead in hot loops.

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -192,8 +192,20 @@ def add_weld_constraint(
         "body1": body1,
         "body2": body2,
     }
+
+    # ⚡ Bolt Optimization:
+    # Hardcode string formatting for common relpose tuple length (7)
+    # instead of using generator expressions and string joins.
+    # This avoids generator allocation and reduces execution time.
     if relpose is not None:
-        attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
+        if len(relpose) == 7:
+            attrs["relpose"] = (
+                f"{relpose[0]:.6f} {relpose[1]:.6f} {relpose[2]:.6f} "
+                f"{relpose[3]:.6f} {relpose[4]:.6f} {relpose[5]:.6f} "
+                f"{relpose[6]:.6f}"
+            )
+        else:
+            attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
 
     return ET.SubElement(equality, "weld", attrib=attrs)
 


### PR DESCRIPTION
💡 What: The optimization replaces the generator expression inside `"".join()` with unrolled f-string formatting when `relpose` has exactly 7 elements in `add_weld_constraint`.

🎯 Why: To prevent the overhead of allocating and executing a generator for small, fixed-size 7D tuples during MJCF XML configuration string generation. This mimics existing optimizations made for `geom_size` and `geom_euler`.

📊 Impact: Reduces overhead by avoiding generator creation when building the equality weld constraint string, particularly in tight loops scaling with joint and body counts.

🔬 Measurement: Verifiable by executing `python -m pytest tests/unit/test_benchmarks.py --benchmark-only -o addopts=""` and ensuring benchmarks run as fast or slightly faster without regressions.

---
*PR created automatically by Jules for task [15404326020336616407](https://jules.google.com/task/15404326020336616407) started by @dieterolson*