### PR TITLE
⚡ Bolt: Optimize relpose string formatting in MJCF helpers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,7 @@
 ## 2024-05-08 - Fast 2D Vector Reductions
 **Learning:** Using `np.sum(..., axis=1)` on small 2D arrays (like shape N, 2) inside tight loops is surprisingly slow due to reduction overhead and intermediate array allocation.
 **Action:** When computing sums over fixed small dimensions (like x, y deviations), slice the 1D arrays and perform element-wise arithmetic (e.g. `dx*dx + dy*dy`) directly to avoid intermediate Nx2 arrays and axis reduction overhead.
+
+## 2026-05-09 - Optimize MJCF XML string formatting in add_weld_constraint for relpose
+**Learning:** Using generator expressions within `"".join()` for `relpose` (which is typically a 7-tuple: x, y, z, qw, qx, qy, qz) incurs unnecessary generator allocation overhead and slows down execution.
+**Action:** Extend the hardcoded string formatting optimization to `relpose` for length 7 to avoid generator overhead in hot loops when building weld constraints.

--- a/SPEC.md
+++ b/SPEC.md
@@ -176,6 +176,7 @@ This header is present in every module-level `.py` file as of the SPDX header up
 - Performance optimizations using unrolled scalar operations over numpy methods for small arrays are encouraged for hot-path calculations, such as in `src/mujoco_models/shared/contracts/preconditions.py` and `src/mujoco_models/shared/utils/geometry.py`.
 - ElementTree (`ET`) loop traversals during XML generation are optimized by avoiding nested loop passes and preferring `.find()` and combined iterators where applicable, as demonstrated in `ExerciseModelBuilder`.
 - Unrolled 1D slice operations (`dx*dx + dy*dy`) are preferred over intermediate 2D array allocations and `np.sum(..., axis=1)` for small matrix reductions, as demonstrated in `src/mujoco_models/optimization/trajectory_optimizer.py`.
+- Generator expressions used inside string joining operations are avoided for fixed short tuples (e.g., sizes, rotations, relative poses) to skip unnecessary generator allocation overhead during model building.
 
 ### CI Runner Routing
 

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -192,8 +192,17 @@ def add_weld_constraint(
         "body1": body1,
         "body2": body2,
     }
+    # ⚡ Bolt Optimization:
+    # Hardcode string formatting for exactly 7-element relpose
+    # to avoid generator expression overhead inside tight loops.
     if relpose is not None:
-        attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
+        if len(relpose) == 7:
+            attrs["relpose"] = (
+                f"{relpose[0]:.6f} {relpose[1]:.6f} {relpose[2]:.6f} "
+                f"{relpose[3]:.6f} {relpose[4]:.6f} {relpose[5]:.6f} {relpose[6]:.6f}"
+            )
+        else:
+            attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
 
     return ET.SubElement(equality, "weld", attrib=attrs)
 


### PR DESCRIPTION
💡 **What**: Optimized the formatting of the `relpose` 7-element tuple in `src/mujoco_models/shared/utils/mjcf_helpers.py`'s `add_weld_constraint` function by using a hardcoded f-string instead of `" ".join(f"{v:.6f}" for v in relpose)`. Also updated `.jules/bolt.md` and `SPEC.md`.
🎯 **Why**: Using generator expressions within `join()` for small fixed-size iterables creates unnecessary overhead. In the hot path of building MuJoCo models (which iterates through many segments and constraints), removing this generator allocation improves execution speed.
📊 **Impact**: Reduces total execution time and generator allocation overhead in `add_weld_constraint`, contributing to a slightly faster overall model build time (as evidenced by cProfile internal execution time drops and modest OPS improvements in `pytest tests/unit/test_benchmarks.py`).
🔬 **Measurement**: Verify via `python -m pytest tests/unit/test_benchmarks.py --benchmark-only -o addopts=""`.

---
*PR created automatically by Jules for task [11143391871084173586](https://jules.google.com/task/11143391871084173586) started by @dieterolson*