### PR TITLE
⚡ Bolt: Optimize relpose string formatting in mjcf_helpers.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,7 @@
 ## 2024-05-08 - Fast 2D Vector Reductions
 **Learning:** Using `np.sum(..., axis=1)` on small 2D arrays (like shape N, 2) inside tight loops is surprisingly slow due to reduction overhead and intermediate array allocation.
 **Action:** When computing sums over fixed small dimensions (like x, y deviations), slice the 1D arrays and perform element-wise arithmetic (e.g. `dx*dx + dy*dy`) directly to avoid intermediate Nx2 arrays and axis reduction overhead.
+
+## 2026-04-26 - Optimize MJCF XML string formatting in add_weld_constraint for relpose
+**Learning:** Similar to `geom_size` and `geom_euler`, using generator expressions within `"".join()` for `relpose` (which is typically a 7-tuple) incurs unnecessary generator allocation overhead.
+**Action:** Extend the hardcoded string formatting optimization to `relpose` for length 7 to avoid generator overhead in hot loops.

--- a/SPEC.md
+++ b/SPEC.md
@@ -176,6 +176,7 @@ This header is present in every module-level `.py` file as of the SPDX header up
 - Performance optimizations using unrolled scalar operations over numpy methods for small arrays are encouraged for hot-path calculations, such as in `src/mujoco_models/shared/contracts/preconditions.py` and `src/mujoco_models/shared/utils/geometry.py`.
 - ElementTree (`ET`) loop traversals during XML generation are optimized by avoiding nested loop passes and preferring `.find()` and combined iterators where applicable, as demonstrated in `ExerciseModelBuilder`.
 - Unrolled 1D slice operations (`dx*dx + dy*dy`) are preferred over intermediate 2D array allocations and `np.sum(..., axis=1)` for small matrix reductions, as demonstrated in `src/mujoco_models/optimization/trajectory_optimizer.py`.
+- Hardcoded string formatting is preferred over `"".join(f"{v:.6f}" for v in ...)` generator expressions for known small fixed-size tuples (e.g. 1D, 2D, 3D, or 7D arrays) during MJCF generation to avoid generator allocation overhead.
 
 ### CI Runner Routing
 

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -192,8 +192,18 @@ def add_weld_constraint(
         "body1": body1,
         "body2": body2,
     }
+
+    # ⚡ Bolt Optimization:
+    # Hardcode string formatting for the common 7-element relpose
+    # to avoid generator allocation and reduce execution time.
     if relpose is not None:
-        attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
+        if len(relpose) == 7:
+            attrs["relpose"] = (
+                f"{relpose[0]:.6f} {relpose[1]:.6f} {relpose[2]:.6f} "
+                f"{relpose[3]:.6f} {relpose[4]:.6f} {relpose[5]:.6f} {relpose[6]:.6f}"
+            )
+        else:
+            attrs["relpose"] = " ".join(f"{v:.6f}" for v in relpose)
 
     return ET.SubElement(equality, "weld", attrib=attrs)
 


### PR DESCRIPTION
💡 **What:** I replaced the `"".join(...)` generator expression for the common 7-element `relpose` parameter in `add_weld_constraint` with unrolled f-string formatting.
🎯 **Why:** To eliminate string generator allocation overhead in tight loops that occur when writing MJCF welds, continuing our practice of applying micro-optimizations in string construction wherever possible.
📊 **Impact:** Provides a slight performance gain by completely bypassing generator and iteration overhead in the standard 7-element pose string serialization.
🔬 **Measurement:** Confirmed the functional correctness using `pytest tests/` and verified basic baseline operations with `pytest tests/unit/test_benchmarks.py --benchmark-only`.

---
*PR created automatically by Jules for task [16637030355294144336](https://jules.google.com/task/16637030355294144336) started by @dieterolson*