### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#263)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,4 +2,27 @@
 
 This file is intentionally minimal. Shared fixtures and hooks live here
 so pytest can discover them from any test subdirectory.
+
+Fleet Testing Standards §5: thread-safety and headless env vars must be
+set before any heavy import (numpy/MKL, matplotlib, Qt, MuJoCo's GLFW).
+See: docs/FLEET_TESTING_STANDARDS.md in Repository_Management.
 """
+from __future__ import annotations
+
+import os
+
+# C-extension thread safety. Many "xdist worker crashed" failures come
+# from MKL/OpenBLAS forking under xdist. Pin to single-threaded for tests;
+# production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend. Matters for MuJoCo's GLFW viewer paths and any
+# indirect PyQt/PySide imports during test collection.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,14 +96,51 @@ pythonpath = ["src"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20 -n auto --dist loadscope"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 60
+timeout_method = "thread"
+
+# Default lane: fast, deterministic, offline. Heavy paths (slow,
+# live_simulation, e2e, requires_network) are deselected.
+addopts = """
+  -ra
+  -q
+  --strict-markers
+  --strict-config
+  --durations=20
+  -n auto
+  --dist loadscope
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
 markers = [
-    "slow: marks tests as slow",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
-    "requires_mujoco: tests requiring mujoco package",
-    "benchmark: marks tests as performance benchmarks",
+  # ---- tier markers ----
+  "unit: pure logic, fully mocked, < 100 ms wall-clock",
+  "integration: cross-module / file-system / process boundaries, < 5 s",
+  "e2e: full-stack smoke tests; nightly + release gate only",
+  "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+  "live_simulation: requires a real physics / math engine; deselect by default",
+
+  # ---- environment markers ----
+  "requires_network: needs real outbound network; deselect by default",
+  "requires_gpu: needs CUDA / Metal / ROCm",
+  "requires_gl: needs OpenGL or a display",
+  "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+  # ---- per-engine markers ----
+  "requires_mujoco: skip when import mujoco fails",
+  "requires_drake: skip when import pydrake fails",
+  "requires_pinocchio: skip when pinocchio is the stub PyPI wheel",
+  "requires_opensim: skip when import opensim fails",
+  "requires_matlab: skip when MATLAB Engine for Python is unavailable",
+
+  # ---- workflow markers ----
+  "serial: must run with -n 0 (xdist parallel breaks this test)",
+  "benchmark: deterministic perf smoke; not a primary correctness gate",
+  "smoke: release-blocking smoke; subset of e2e",
 ]
+
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",


### PR DESCRIPTION
## Summary
- Apply additive Phase 1 of the [Fleet Testing Standards](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md) (sections 2 and 5).
- `pyproject.toml`: adds 60s thread timeout, async-io defaults, the standard tier/environment/per-engine/workflow marker set, and default-lane deselection of `slow / live_simulation / e2e / requires_network`. Existing markers and filterwarnings preserved; coverage gate unchanged.
- `conftest.py`: pins OMP/OPENBLAS/MKL/NUMEXPR thread counts to 1 and sets `MPLBACKEND=Agg` + `QT_QPA_PLATFORM=offscreen` before any heavy import. The Qt env var matters here for MuJoCo's GLFW viewer path under xdist.

## Test plan
- [x] `pytest --collect-only -q` passes (737 tests collected, no errors)
- [ ] CI green on the PR

Closes #263
Refs D-sorganization/Repository_Management#1140

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>