### PR TITLE
feat: publish model_pack discovery surface for UpstreamDrift (#266)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -198,6 +198,10 @@ jobs:
             exit 1
           }
 
+      - name: Verify model_pack entry-point surface (issue #266)
+        run: |
+          python3 -c "from mujoco_models.model_pack import resolve, manifest, list_exercises; resolve(); manifest(); list_exercises()"
+
       - name: Run Test Suite
         run: |
           python3 -m pytest \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ with open("squat.xml", "w") as f:
 - **DRY** -- Shared base class, shared barbell/body models, shared MJCF helpers
 - **Law of Demeter** -- Exercise builders interact only with public APIs of shared components
 
+## Used by UpstreamDrift
+
+This repo publishes a `model_pack/v1` manifest (`model_pack.yaml` at repo
+root) and a `biomech.model_pack` entry point (`mujoco_models.model_pack`)
+so that the UpstreamDrift launcher can discover and host these exercises.
+See the umbrella tracking issue:
+[UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179).
+
+Discovery API:
+
+```python
+from mujoco_models.model_pack import resolve, manifest, list_exercises
+
+resolve()         # absolute path to the installed exercises directory
+manifest()        # parsed model_pack.yaml as a dict
+list_exercises()  # ['squat', 'deadlift', ...]
+```
+
+CLI export contract:
+
+```bash
+python -m mujoco_models --exercise gait --export /tmp/gait.xml
+mujoco-models --list-exercises
+```
+
 ## License
 
 MIT

--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -1,0 +1,23 @@
+schema: model_pack/v1
+repo: MuJoCo_Models
+package: mujoco_models
+engine: mujoco
+engine_version: ">=3.0,<4"
+anthropometrics: winter_2009
+format: mjcf
+models_root: src/mujoco_models/exercises
+exercises:
+  - id: squat
+    path: src/mujoco_models/exercises/squat
+  - id: deadlift
+    path: src/mujoco_models/exercises/deadlift
+  - id: bench_press
+    path: src/mujoco_models/exercises/bench_press
+  - id: snatch
+    path: src/mujoco_models/exercises/snatch
+  - id: clean_and_jerk
+    path: src/mujoco_models/exercises/clean_and_jerk
+  - id: gait
+    path: src/mujoco_models/exercises/gait
+  - id: sit_to_stand
+    path: src/mujoco_models/exercises/sit_to_stand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.4,<3.0.0",
     "matplotlib>=3.7.0",
-    "mujoco>=3.3.0",
+    "mujoco>=3.3.0,<4",
+    "PyYAML>=6.0.0",
 ]
 
 [project.optional-dependencies]
@@ -43,6 +44,9 @@ dev = [
 [project.scripts]
 mujoco-models = "mujoco_models.__main__:main"
 
+[project.entry-points."biomech.model_pack"]
+mujoco_models = "mujoco_models.model_pack"
+
 [project.urls]
 Homepage = "https://github.com/D-sorganization/MuJoCo_Models"
 Repository = "https://github.com/D-sorganization/MuJoCo_Models"
@@ -52,10 +56,13 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["src/**/*"]
+include = ["src/**/*", "model_pack.yaml"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mujoco_models"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"model_pack.yaml" = "mujoco_models/model_pack.yaml"
 
 [tool.ruff]
 line-length = 88

--- a/src/mujoco_models/__main__.py
+++ b/src/mujoco_models/__main__.py
@@ -21,11 +21,21 @@ logger = logging.getLogger(__name__)
 
 
 def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
-    """Add the positional ``exercise`` argument."""
+    """Add the ``exercise`` argument as positional or via ``--exercise``."""
+    choices = sorted(set(EXERCISE_REGISTRY.keys()))
     parser.add_argument(
         "exercise",
-        choices=sorted(set(EXERCISE_REGISTRY.keys())),
+        nargs="?",
+        choices=choices,
+        default=None,
         help="Exercise to generate a model for.",
+    )
+    parser.add_argument(
+        "--exercise",
+        dest="exercise_flag",
+        choices=choices,
+        default=None,
+        help="Alternative to the positional argument; identical semantics.",
     )
 
 
@@ -61,10 +71,25 @@ def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
         help="Output file path (default: stdout).",
     )
     parser.add_argument(
+        "--export",
+        type=str,
+        default=None,
+        help="Alias for --output, used by the UpstreamDrift launcher contract.",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
         help="Enable verbose logging.",
+    )
+
+
+def _add_discovery_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add discovery flags used by the UpstreamDrift launcher contract."""
+    parser.add_argument(
+        "--list-exercises",
+        action="store_true",
+        help="Print the list of declared exercises and exit.",
     )
 
 
@@ -77,6 +102,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_exercise_argument(parser)
     _add_anthropometry_arguments(parser)
     _add_output_arguments(parser)
+    _add_discovery_arguments(parser)
     return parser
 
 
@@ -142,20 +168,52 @@ def _emit_xml(xml_str: str, output: str | None) -> int:
     return 0
 
 
+def _resolve_exercise(args: argparse.Namespace) -> str | None:
+    """Return the chosen exercise from either positional or ``--exercise``."""
+    if args.exercise and args.exercise_flag and args.exercise != args.exercise_flag:
+        logger.error(
+            "Conflicting exercise selection: positional=%r, --exercise=%r",
+            args.exercise,
+            args.exercise_flag,
+        )
+        return None
+    return args.exercise or args.exercise_flag
+
+
+def _handle_list_exercises() -> int:
+    """Emit the declared exercise IDs on stdout and exit 0."""
+    from mujoco_models.model_pack import list_exercises
+
+    for name in list_exercises():
+        sys.stdout.write(f"{name}\n")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI main function. Returns 0 on success, 1 on error."""
     args = _build_parser().parse_args(argv)
     _configure_logging(args.verbose)
 
+    if args.list_exercises:
+        return _handle_list_exercises()
+
+    exercise = _resolve_exercise(args)
+    if exercise is None:
+        logger.error(
+            "No exercise specified. Use --exercise <name> or --list-exercises.",
+        )
+        return 1
+
     config = _build_config_from_args(args)
     if config is None:
         return 1
 
-    xml_str = _build_model_xml(args.exercise, config)
+    xml_str = _build_model_xml(exercise, config)
     if xml_str is None:
         return 1
 
-    return _emit_xml(xml_str, args.output)
+    output = args.export if args.export is not None else args.output
+    return _emit_xml(xml_str, output)
 
 
 if __name__ == "__main__":

--- a/src/mujoco_models/model_pack.py
+++ b/src/mujoco_models/model_pack.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+"""Model-pack manifest discovery for the UpstreamDrift launcher integration.
+
+This module exposes the stable entry-point surface that UpstreamDrift uses
+to find this repo's exercise content. See issue
+https://github.com/D-sorganization/MuJoCo_Models/issues/266 and umbrella
+https://github.com/D-sorganization/UpstreamDrift/issues/5179.
+
+The manifest is loaded from ``model_pack.yaml`` which is shipped both at
+the repo root (for source checkouts) and inside the installed package
+(for ``pip install`` consumers) via ``importlib.resources``.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_MANIFEST_FILENAME = "model_pack.yaml"
+
+
+def _load_manifest_text() -> str:
+    """Return the raw contents of ``model_pack.yaml``.
+
+    Looks first inside the installed package (the wheel ships the file via
+    ``force-include``). Falls back to the source-tree repo root so that
+    editable installs / source checkouts continue to work even when the
+    package-data copy is absent.
+    """
+    package_resource = files("mujoco_models").joinpath(_MANIFEST_FILENAME)
+    if package_resource.is_file():
+        return package_resource.read_text(encoding="utf-8")
+
+    repo_root_candidate = Path(__file__).resolve().parents[2] / _MANIFEST_FILENAME
+    if repo_root_candidate.is_file():
+        return repo_root_candidate.read_text(encoding="utf-8")
+
+    raise FileNotFoundError(
+        f"{_MANIFEST_FILENAME} not found in package data or repo root",
+    )
+
+
+@cache
+def manifest() -> dict[str, Any]:
+    """Load and return the ``model_pack.yaml`` contents as a dict.
+
+    The result is cached because the manifest is immutable for the lifetime
+    of the process. Returns a fresh shallow-copyable dict on each access by
+    way of ``yaml.safe_load``.
+    """
+    parsed = yaml.safe_load(_load_manifest_text())
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"{_MANIFEST_FILENAME} must parse to a mapping, "
+            f"got {type(parsed).__name__}",
+        )
+    return cast("dict[str, Any]", parsed)
+
+
+def resolve() -> Path:
+    """Return the absolute path to this package's models root directory.
+
+    Postcondition: returned path exists and is a directory.
+    """
+    root = Path(str(files("mujoco_models").joinpath("exercises"))).resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"models root not found: {root}")
+    return root
+
+
+def list_exercises() -> list[str]:
+    """Return the list of exercise IDs declared by the manifest."""
+    exercises = manifest().get("exercises", [])
+    return [str(entry["id"]) for entry in exercises]

--- a/tests/test_model_pack.py
+++ b/tests/test_model_pack.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 D-sorganization
+"""Tests for the ``model_pack`` discovery surface (issue #266).
+
+These verify the contract UpstreamDrift (#5179) consumes:
+
+* ``resolve()`` returns an existing models-root directory.
+* ``manifest()`` matches the YAML on disk.
+* ``list_exercises()`` returns the declared IDs.
+* The ``mujoco-models`` CLI exports a valid MJCF for each declared exercise
+  and the result parses with ``mujoco.MjModel.from_xml_path``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mujoco_models import model_pack as model_pack_mod
+from mujoco_models.__main__ import main as cli_main
+from mujoco_models.model_pack import list_exercises, manifest, resolve
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PATH = REPO_ROOT / "model_pack.yaml"
+
+EXPECTED_EXERCISES = [
+    "squat",
+    "deadlift",
+    "bench_press",
+    "snatch",
+    "clean_and_jerk",
+    "gait",
+    "sit_to_stand",
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_manifest_cache() -> None:
+    """Drop the ``functools.cache`` so per-test mutation cannot leak."""
+    model_pack_mod.manifest.cache_clear()
+
+
+@pytest.mark.unit
+class TestManifest:
+    def test_manifest_matches_yaml_on_disk(self) -> None:
+        on_disk = yaml.safe_load(YAML_PATH.read_text(encoding="utf-8"))
+        assert manifest() == on_disk
+
+    def test_manifest_declares_seven_exercises(self) -> None:
+        ids = [e["id"] for e in manifest()["exercises"]]
+        assert ids == EXPECTED_EXERCISES
+
+    def test_manifest_has_required_top_level_fields(self) -> None:
+        m = manifest()
+        assert m["schema"] == "model_pack/v1"
+        assert m["package"] == "mujoco_models"
+        assert m["engine"] == "mujoco"
+        assert m["engine_version"] == ">=3.0,<4"
+        assert m["format"] == "mjcf"
+        assert m["anthropometrics"] == "winter_2009"
+        assert m["models_root"] == "src/mujoco_models/exercises"
+
+    def test_list_exercises(self) -> None:
+        assert list_exercises() == EXPECTED_EXERCISES
+
+
+@pytest.mark.unit
+class TestResolve:
+    def test_resolve_returns_existing_directory(self) -> None:
+        root = resolve()
+        assert root.is_dir()
+
+    def test_resolve_contains_seven_exercise_subdirs(self) -> None:
+        root = resolve()
+        for exercise_id in EXPECTED_EXERCISES:
+            assert (root / exercise_id).is_dir(), (
+                f"missing exercise subdir: {exercise_id}"
+            )
+
+
+@pytest.mark.unit
+def test_cli_list_exercises_smoke(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli_main(["--list-exercises"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    listed = [line.strip() for line in captured.out.splitlines() if line.strip()]
+    assert listed == EXPECTED_EXERCISES
+
+
+@pytest.mark.unit
+def test_cli_export_writes_file(tmp_path: Path) -> None:
+    out = tmp_path / "squat.xml"
+    exit_code = cli_main(["--exercise", "squat", "--export", str(out)])
+    assert exit_code == 0
+    assert out.is_file()
+    assert "<mujoco" in out.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_cli_console_script_smoke(tmp_path: Path) -> None:
+    """The ``mujoco-models`` console script must resolve to our ``main``."""
+    script = shutil.which("mujoco-models")
+    if script is None:
+        # Not installed in this environment — fall back to module form, which
+        # exercises the same dispatch path.
+        result = subprocess.run(
+            [sys.executable, "-m", "mujoco_models", "--list-exercises"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    else:
+        result = subprocess.run(
+            [script, "--list-exercises"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode == 0, result.stderr
+    listed = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert set(listed) >= set(EXPECTED_EXERCISES)
+
+
+try:
+    import mujoco
+
+    _MUJOCO_AVAILABLE = True
+except ImportError:
+    _MUJOCO_AVAILABLE = False
+
+
+@pytest.mark.live_simulation
+@pytest.mark.skipif(not _MUJOCO_AVAILABLE, reason="mujoco not installed")
+@pytest.mark.parametrize("exercise", EXPECTED_EXERCISES)
+def test_cli_export_parses_with_mujoco(
+    exercise: str,
+    tmp_path: Path,
+) -> None:
+    """Each declared exercise must export an MJCF that MuJoCo can parse."""
+    out = tmp_path / f"{exercise}.xml"
+    exit_code = cli_main(["--exercise", exercise, "--export", str(out)])
+    assert exit_code == 0
+    model = mujoco.MjModel.from_xml_path(str(out))
+    assert model.nbody > 1

--- a/tests/unit/optimization/test_exercise_objectives.py
+++ b/tests/unit/optimization/test_exercise_objectives.py
@@ -45,9 +45,9 @@ class TestPhaseConstraints:
     @pytest.mark.parametrize("name", sorted(EXPECTED_NAMES))
     def test_fractions_in_range(self, name: str):  # type: ignore
         for phase in EXERCISE_OBJECTIVES[name].phases:
-            assert (
-                0.0 <= phase.fraction <= 1.0
-            ), f"{name}/{phase.name}: fraction {phase.fraction} out of range"
+            assert 0.0 <= phase.fraction <= 1.0, (
+                f"{name}/{phase.name}: fraction {phase.fraction} out of range"
+            )
 
     @pytest.mark.parametrize("name", sorted(EXPECTED_NAMES))
     def test_fractions_monotonic(self, name: str):  # type: ignore

--- a/tests/unit/test_pip_audit_ignores.py
+++ b/tests/unit/test_pip_audit_ignores.py
@@ -80,9 +80,9 @@ class TestPipAuditIgnores:
     )
     def test_expiration_date_format(self, entry: dict) -> None:
         exp = entry["expires"]
-        assert (
-            len(exp) == 10 and exp[4] == "-" and exp[7] == "-"
-        ), f"{exp} must be YYYY-MM-DD"
+        assert len(exp) == 10 and exp[4] == "-" and exp[7] == "-", (
+            f"{exp} must be YYYY-MM-DD"
+        )
 
     @pytest.mark.parametrize(
         "entry",
@@ -108,6 +108,6 @@ class TestPipAuditIgnores:
     )
     def test_tracking_issue_format(self, entry: dict) -> None:
         issue = entry["tracking_issue"]
-        assert issue.startswith(
-            "MuJoCo_Models#176-"
-        ), f"{issue} must reference MuJoCo_Models#176-N"
+        assert issue.startswith("MuJoCo_Models#176-"), (
+            f"{issue} must reference MuJoCo_Models#176-N"
+        )

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -10,9 +10,9 @@ from mujoco_models.exercises.base import ExerciseModelBuilder
 class TestExerciseRegistry:
     def test_all_entries_are_builder_subclasses(self) -> None:
         for name, cls in EXERCISE_REGISTRY.items():
-            assert issubclass(
-                cls, ExerciseModelBuilder
-            ), f"{name} -> {cls} is not an ExerciseModelBuilder"
+            assert issubclass(cls, ExerciseModelBuilder), (
+                f"{name} -> {cls} is not an ExerciseModelBuilder"
+            )
 
     def test_minimum_exercises(self) -> None:
         expected = {"squat", "bench_press", "deadlift", "snatch", "clean_and_jerk"}


### PR DESCRIPTION
## Summary

Implements the MuJoCo_Models side of the UpstreamDrift biomechanics-fleet integration ([UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179)). Publishes the stable launcher-discovery surface UpstreamDrift uses to find and host this repo's exercise content.

- `model_pack.yaml` (schema `model_pack/v1`) at repo root; force-included in the wheel via hatch so `resolve()` works in both source and installed layouts.
- `mujoco_models.model_pack`: `resolve()`, `manifest()`, `list_exercises()`.
- `[project.entry-points."biomech.model_pack"]` registered in `pyproject.toml`.
- CLI gains `--exercise` / `--export` / `--list-exercises` to match the launcher contract; positional `exercise` argument preserved for backwards compatibility.
- CI smoke-imports the discovery surface to fail fast on regressions.
- README gets a "Used by UpstreamDrift" section.

Closes #266.

## Test plan

- [x] `pytest tests/test_model_pack.py` — 9 tests pass (manifest parity, resolve(), list_exercises(), CLI list/export, console-script smoke).
- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.
- [x] `mypy` — no issues on new sources.
- [ ] CI runs the new "Verify model_pack entry-point surface" step.
- [ ] `live_simulation`-marked test (`test_cli_export_parses_with_mujoco`) runs in environments with MuJoCo installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)