### PR TITLE
ci(standard): parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -139,7 +139,6 @@ jobs:
   rust:
     needs:
       - pick-runner
-      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 25
     steps:
@@ -168,11 +167,11 @@ jobs:
   tests:
     needs:
       - pick-runner
-      - quality-gate
       - rust
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.10", "3.11", "3.12"]
     steps:


### PR DESCRIPTION
Part of 2026-05-17 fleet CI parallelization campaign (15/15 complete with this PR). Pattern: jobs flattened from `needs: [pick-runner, quality-gate]` to `needs: pick-runner` since `quality-gate` declares no `outputs:` and no downstream step consumes its outputs. Matrix `fail-fast: false` added so all matrix entries report failures independently. Failure-visibility benefit: agents remediating failing PRs see ALL failures on the first run instead of one-fix-at-a-time across multiple queue cycles.

## Changes
- `rust`: dropped `quality-gate` from `needs:`
- `tests`: dropped `quality-gate` from `needs:` (still gated on `rust`)
- `tests` matrix: added `fail-fast: false`