### PR TITLE
⚡ Bolt: Optimize `np.all(np.isfinite(arr))` to `np.isfinite(arr).all()`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2026-05-17 - Optimize scalar validation with inline math.isfinite
 **Learning:** Checking for finity dynamically using a nested python function call in tight loops adds unnecessary overhead. The `_require_scalar_finite` check called multiple times per attribute within methods like `require_positive` adds significant execution time.
 **Action:** Inline `math.isfinite` check directly inside the core `require_positive` and `require_non_negative` checks. Use a `try...except TypeError` block to catch instances where the value is an array or object, which is much faster than delegating to another python function. This removes stack allocation overheads for millions of checks.
+
+## 2026-05-19 - Optimize numpy finite checks for arrays
+**Learning:** Checking for finity on numpy arrays using `np.all(np.isfinite(arr))` uses the `np.all` function, which has to dispatch and determine the type of input. This overhead is small but stacks up in tight loops over thousands of arrays. Since `np.isfinite(arr)` already produces a numpy array of booleans, it's faster to call the `.all()` method on the resulting array directly.
+**Action:** Use `np.isfinite(arr).all()` rather than `np.all(np.isfinite(arr))` for checking if an array contains finite values. Also consider falling back to `np.asarray()` and standard methods via duck typing when a function might accept raw numbers or tuples.

--- a/SPEC.md
+++ b/SPEC.md
@@ -179,6 +179,7 @@ This header is present in every module-level `.py` file as of the SPDX header up
 - Unrolled 1D slice operations (`dx*dx + dy*dy`) are preferred over intermediate 2D array allocations and `np.sum(..., axis=1)` for small matrix reductions, as demonstrated in `src/mujoco_models/optimization/trajectory_optimizer.py`.
 - Hardcoded string formatting is preferred over `"".join(f"{v:.6f}" for v in ...)` generator expressions for known small fixed-size tuples (e.g. 1D, 2D, 3D, or 7D arrays) during MJCF generation to avoid generator allocation overhead.
 - Vectorized array operations like `np.interp` over all frames at once are preferred over Python `for` loops evaluating piecewise functions frame-by-frame during trajectory generation.
+- Checking for finiteness of NumPy arrays using `np.isfinite(arr).all()` is preferred over `np.all(np.isfinite(arr))` to avoid Python function dispatch overhead in tight loops.
 
 ### CI Runner Routing
 

--- a/src/mujoco_models/optimization/trajectory_optimizer.py
+++ b/src/mujoco_models/optimization/trajectory_optimizer.py
@@ -300,7 +300,7 @@ def compute_bar_path_cost(
 
 def _validate_array_finite(arr: np.ndarray, name: str) -> None:
     """Check that an array contains only finite values."""
-    if not np.all(np.isfinite(arr)):
+    if not np.isfinite(arr).all():
         msg = f"{name} contains non-finite values"
         raise ValidationError(msg)
 

--- a/src/mujoco_models/shared/contracts/preconditions.py
+++ b/src/mujoco_models/shared/contracts/preconditions.py
@@ -68,9 +68,17 @@ def require_finite(arr: ArrayLike, name: str) -> None:
             raise ValidationError(f"{name} contains non-finite values")
         return
 
-    a = np.asarray(arr, dtype=float)
-    if not np.all(np.isfinite(a)):
-        raise ValidationError(f"{name} contains non-finite values")
+    try:
+        # Try to use array's fast methods first if it's already a numpy array
+        if not np.isfinite(arr).all():
+            raise ValidationError(f"{name} contains non-finite values")
+    except TypeError as exc:
+        try:
+            a = np.asarray(arr, dtype=float)
+            if not np.isfinite(a).all():
+                raise ValidationError(f"{name} contains non-finite values") from None
+        except (TypeError, ValueError):
+            raise ValidationError(f"{name} contains non-finite values") from exc
 
 
 def require_in_range(value: float, low: float, high: float, name: str) -> None:


### PR DESCRIPTION
⚡ Bolt: Optimize `np.all(np.isfinite(arr))` to `np.isfinite(arr).all()`

💡 What: Changed the logic checking for finite arrays to call the `.all()` method on the resulting `np.isfinite()` boolean array instead of passing it to the generic `np.all()` function.
🎯 Why: `np.all()` introduces dispatch overhead in tight array validation loops. Using `np.isfinite(arr).all()` speeds up the validation process. Additionally, falling back dynamically on type errors saves the cost of casting arrays directly using `np.asarray()` if they already pass array tests directly.
📊 Impact: Performance is slightly improved and avoids extra unnecessary iterations per array validation check within loops. Evaluated in performance tests to remove function overhead.
🔬 Measurement: Verify via running the benchmark suite: `python -m pytest tests/unit/test_benchmarks.py --benchmark-only -o addopts=""`.

---
*PR created automatically by Jules for task [15207162691863004726](https://jules.google.com/task/15207162691863004726) started by @dieterolson*