### PR TITLE
docs: add Hook bypass policy section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,21 @@ docker run -it mujoco-models bash                # interactive shell
 - Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
 - Branch naming: `feat/description`, `fix/description`
 - PRs must pass CI before merge
+
+## Hook bypass policy
+
+**Never use `git commit --no-verify` or `git push --no-verify` unless the hook itself is broken** (tooling not installed, hook script crashes). It is *not* an acceptable workaround for a hook that flags real issues.
+
+### When a hook fails on something you didn't touch
+
+The hook is scoped to *your diff*. If `fleet-fast-guardrails` or any other guardrail reports a violation in a file you didn't change, that's a regression — file an issue against `Repository_Management`. Bypassing locally doesn't help: the same checks run in CI's `quality-gate` and will block the PR.
+
+### When the hook is legitimately broken
+
+Open an issue in `Repository_Management`. If you must bypass once to land an urgent fix, include the hook error in the commit body and link the tracking issue. **Do not normalize `--no-verify` as a workaround.**
+
+### Enforcement
+
+Branch protection requires the CI `quality-gate` check on every PR. That check runs the same lint, format, type, and security gates as the hooks. `--no-verify` only delays feedback — it cannot land code that would have failed the hook.
+
+For the canonical hook contract, see [`Repository_Management/docs/FLEET_HOOK_STANDARDS.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_HOOK_STANDARDS.md).


### PR DESCRIPTION
## Summary

Append a "Hook bypass policy" section to CLAUDE.md so every agent working in this repo sees the no-`--no-verify` rule at the top of context.

The canonical contract lives in [`Repository_Management/docs/FLEET_HOOK_STANDARDS.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_HOOK_STANDARDS.md) (landing in [#1253](https://github.com/D-sorganization/Repository_Management/pull/1253)).

## Why

Fleet-wide coverage of the `--no-verify` overuse problem. The technical root cause (`fleet_hooks.py` false-firing on the whole working tree) is fixed via [Repository_Management#1253](https://github.com/D-sorganization/Repository_Management/pull/1253), [Tools#3075](https://github.com/D-sorganization/Tools/pull/3075), and [Gasification_Model#3850](https://github.com/D-sorganization/Gasification_Model/pull/3850). This PR closes the policy gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)