### PR TITLE
⚡ Bolt: Optimize recursive XML serialization buffering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -137,3 +137,7 @@
 
 **Learning:** During profiling, we found that attribute lookup (e.g. `buffer.extend` and `buffer.append`) inside tightly recursive algorithms like `_fast_serialize_node` accounts for measurable execution time. Furthermore, simple wrapper functions like `_fast_escape_attrib` add unnecessary python call frame overhead.
 **Action:** When implementing custom recursive tree traversal functions, explicitly pass bounded methods (e.g., `buffer.extend` and `buffer.append`) as positional arguments to avoid repeatedly resolving them. Also, inline simple fast-path delegate functions (like early checks for string escaping) directly into the calling logic. This reduces XML serialization time by nearly 30% in highly nested structures.
+
+## 2024-05-18 - Avoid buffer_extend with inline tuples in recursive serialization
+**Learning:** Calling `list.extend` with inline tuples (e.g., `buffer.extend(("<", tag))`) inside extremely tight, recursive functions (like custom XML serialization) incurs significant tuple allocation overhead in Python.
+**Action:** When implementing custom recursive string builders or serializers, use multiple successive `list.append(str)` calls instead of a single `list.extend(tuple)` call to bypass tuple creation overhead completely.

--- a/src/mujoco_models/shared/utils/mjcf_helpers.py
+++ b/src/mujoco_models/shared/utils/mjcf_helpers.py
@@ -242,7 +242,6 @@ def indent_xml(elem: ET.Element, level: int = 0) -> None:
 def _fast_serialize_node(  # noqa: C901
     elem: ET.Element,
     buffer: list[str],
-    buffer_extend: Callable[[tuple[str, ...]], None],
     buffer_append: Callable[[str], None],
 ) -> None:
     """Recursively serialize an ElementTree node into a string buffer.
@@ -252,14 +251,21 @@ def _fast_serialize_node(  # noqa: C901
     """
     tag = elem.tag
 
-    buffer_extend(("<", tag))
+    # ⚡ Bolt Optimization: Use multiple append calls instead of extend with
+    # inline tuples to bypass significant tuple allocation overhead.
+    buffer_append("<")
+    buffer_append(tag)
 
     attrib = elem.attrib
     if attrib:
         for k, v in attrib.items():
             if "&" in v or "<" in v or '"' in v or "\n" in v or "\r" in v or "\t" in v:
                 v = _escape_attrib(v)
-            buffer_extend((" ", k, '="', v, '"'))
+            buffer_append(" ")
+            buffer_append(k)
+            buffer_append('="')
+            buffer_append(v)
+            buffer_append('"')
 
     has_children = bool(len(elem))
     if not has_children and not elem.text:
@@ -274,8 +280,10 @@ def _fast_serialize_node(  # noqa: C901
 
         if has_children:
             for child in elem:
-                _fast_serialize_node(child, buffer, buffer_extend, buffer_append)
-        buffer_extend(("</", tag, ">"))
+                _fast_serialize_node(child, buffer, buffer_append)
+        buffer_append("</")
+        buffer_append(tag)
+        buffer_append(">")
 
     if elem.tail:
         tail = elem.tail
@@ -290,8 +298,8 @@ def serialize_model(root: ET.Element) -> str:
     indent_xml(root)
     # ⚡ Bolt Optimization:
     # Use custom recursive serialization instead of ET.tostring for speed.
-    # We pass buffer.extend and buffer.append to avoid attribute lookup overhead
+    # We pass buffer.append to avoid attribute lookup overhead
     # in the recursive calls, and inline the fast-path string checks.
     buf: list[str] = ["<?xml version='1.0' encoding='utf-8'?>\n"]
-    _fast_serialize_node(root, buf, buf.extend, buf.append)
+    _fast_serialize_node(root, buf, buf.append)
     return "".join(buf)


### PR DESCRIPTION
💡 What: Replaced `buffer.extend(("<", tag))` and similar calls with multiple `buffer.append(str)` calls in the custom XML serialization loop `_fast_serialize_node`.
🎯 Why: In tight recursive string building functions, the Python overhead of allocating an inline tuple on every call to `extend` becomes measurable.
📊 Impact: Minor overhead reduction in the cold path MJCF string build process, improving overall model assembly OPS slightly.
🔬 Measurement: Verify the change using `python -m pytest tests/unit/test_benchmarks.py --benchmark-only -o addopts=""`. The tests and benchmarks still pass cleanly with consistent or improved OPS.

---
*PR created automatically by Jules for task [15557123592974551547](https://jules.google.com/task/15557123592974551547) started by @dieterolson*